### PR TITLE
chore/implement-expenses-store

### DIFF
--- a/src/db/expenseRepository.ts
+++ b/src/db/expenseRepository.ts
@@ -1,0 +1,22 @@
+import { eq } from 'drizzle-orm';
+import { expenses } from '@/db/schema';
+import { db } from '@/db';
+import { NewExpense, UpdateExpense } from '@/types/expense';
+
+export const getExpenses = async () => {
+  return await db.select().from(expenses);
+};
+
+export const addExpense = async (input: NewExpense) => {
+  const result = await db.insert(expenses).values(input).returning();
+  return result[0];
+};
+
+export const updateExpense = async (id: number, input: UpdateExpense) => {
+  const result = await db.update(expenses).set(input).where(eq(expenses.id, id)).returning();
+  return result[0];
+};
+
+export const deleteExpense = async (id: number) => {
+  await db.delete(expenses).where(eq(expenses.id, id));
+};

--- a/src/store/expenseStore.ts
+++ b/src/store/expenseStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import { Expense, NewExpense, UpdateExpense } from '@/types/expense';
+import { getExpenses, addExpense, updateExpense, deleteExpense } from '@/db/expenseRepository';
+
+type ExpenseState = {
+  expenses: Expense[];
+  isLoading: boolean;
+  error: string | null;
+};
+
+type ExpenseActions = {
+  fetchExpenses: () => Promise<void>;
+  addExpense: (input: NewExpense) => Promise<void>;
+  updateExpense: (id: number, input: UpdateExpense) => Promise<void>;
+  deleteExpense: (id: number) => Promise<void>;
+};
+
+export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => ({
+  expenses: [],
+  isLoading: false,
+  error: null,
+
+  fetchExpenses: async () => {
+    set({ isLoading: true, error: null});
+    try {
+      const data = await getExpenses();
+      set({ expenses: data });
+    } catch (e) {
+      set({ error: '支出の取得に失敗しました'});
+    } finally {
+      set({ isLoading: false});
+    }
+  },
+
+  addExpense: async (input) => {
+    set({ isLoading: true, error: null });
+    try {
+      const newExpense = await addExpense(input);
+      set((state) => ({ expenses: [...state.expenses, newExpense] }));
+    } catch (e) {
+      set({ error: '支出の追加に失敗しました' });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  updateExpense: async (id, input) => {
+    set({ isLoading: true, error: null });
+    try {
+      const updated = await updateExpense(id, input);
+      set((state) => ({
+        expenses: state.expenses.map((expense) => (expense.id === id ? updated : expense)),
+      }));
+    } catch (e) {
+      set({ error: '支出情報の更新に失敗しました' });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  deleteExpense: async (id) => {
+    set({ isLoading: true, error: null });
+    try {
+      await deleteExpense(id);
+      set((state) => ({
+        expenses: state.expenses.filter((expense) => expense.id !== id),
+      }));
+    } catch (e) {
+      set({ error: '支出の削除に失敗しました' });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -1,0 +1,14 @@
+export type Expense = {
+  id: number;
+  petId: number;
+  categoryId: number;
+  amount: number;
+  date: string;
+  memo: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type NewExpense = Omit<Expense, 'id' | 'createdAt' | 'updatedAt'>;
+
+export type UpdateExpense = Partial<NewExpense>;


### PR DESCRIPTION
## 概要
Zustandを用いたexpensesストアを設計・実装した。支出データの取得・追加・更新・削除の各処理を含む。

## 確認方法
1. ReportScreenにexpenseStoreの各actionを呼び出すボタンを一時追加し、以下を確認した
   - `fetchExpenses`: DBから支出一覧を取得・表示
   - `addExpense`: 支出データの追加
   - `updateExpense`: 先頭データの更新
   - `deleteExpense`: 先頭データの削除
2. isLoading / error の状態が正しく反映されることを確認した
3. 確認後、ReportScreenはもとの状態に戻した

## 影響範囲
- `src/types/expense.ts`: Expense / NewExpense / UpdateExpense 型定義を追加
- `src/db/expenseRepository.ts`: Drizzle ORMを用いたCRUD処理を追加
- `src/store/expenseStore.ts`: Zustandストアを追加

## 関連Issue
close #18