### PR TITLE
feat: 記録画面実装 (#8)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
-import { Text, View } from 'react-native';
 import { TamaguiProvider } from '@tamagui/core'
 import { PortalProvider } from '@tamagui/portal'
 import { useFonts } from 'expo-font';
@@ -56,12 +57,14 @@ export default function App() {
   }
 
   return (
-    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
-      <PortalProvider>
-        <NavigationContainer>
-          <RootNavigator />
-        </NavigationContainer>
-      </PortalProvider>
-    </TamaguiProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+        <PortalProvider>
+          <NavigationContainer>
+            <RootNavigator />
+          </NavigationContainer>
+        </PortalProvider>
+      </TamaguiProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,7 @@ module.exports = function (api) {
           disableExtraction: true,
         },
       ],
+      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,11 @@
         "react-hook-form": "^7.74.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
-        "react-native-reanimated": "~3.16.1",
+        "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
+        "react-native-worklets": "0.5.1",
         "tamagui": "2.0.0-rc.41",
         "zod": "^4.4.1",
         "zustand": "^5.0.12"
@@ -280,9 +281,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1380,12 +1381,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -12515,27 +12516,30 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.16.7",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.7.tgz",
-      "integrity": "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
+      "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4"
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "^7.7.2"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "0.78 - 0.82",
+        "react-native-worklets": "0.5 - 0.8"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -12576,6 +12580,42 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/noto-sans-jp": "^0.4.3",
+        "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.2.2",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "8.4.4",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.12",
@@ -31,6 +33,7 @@
         "react-dom": "19.1.0",
         "react-hook-form": "^7.74.0",
         "react-native": "0.81.5",
+        "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -1545,6 +1548,18 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
@@ -3016,6 +3031,17 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
@@ -3503,6 +3529,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -6135,6 +6184,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -8869,17 +8924,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9498,6 +9542,21 @@
       "dependencies": {
         "hermes-estree": "0.33.3"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -12428,6 +12487,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",
+    "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.12",
@@ -32,6 +34,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.74.0",
     "react-native": "0.81.5",
+    "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     "react-hook-form": "^7.74.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-reanimated": "~3.16.1",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
+    "react-native-worklets": "0.5.1",
     "tamagui": "2.0.0-rc.41",
     "zod": "^4.4.1",
     "zustand": "^5.0.12"

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,73 @@
+import { AlertDialog } from '@tamagui/alert-dialog';
+import { Button } from '@tamagui/button';
+import { fontSizes } from '../../tamagui.config';
+import { XStack } from '@tamagui/stacks';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  buttonLabel?: string;
+  onConfirm?: () => void;
+};
+
+export default function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  buttonLabel = 'OK',
+  onConfirm,
+}: Props) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay />
+        <AlertDialog.Content
+          backgroundColor="$ivory"
+          borderRadius={16}
+          padding={24}
+        >
+          <AlertDialog.Title
+            fontSize={fontSizes.heading2}
+            color="$greige"
+            textAlign="center"
+          >
+            {title}
+          </AlertDialog.Title>
+          <XStack>
+            <AlertDialog.Cancel asChild>
+              <Button
+                backgroundColor="$sage"
+                borderRadius={30}
+                paddingHorizontal={32}
+                marginHorizontal={16}
+                marginTop={16}
+                borderWidth={0}
+                onPress={() => onOpenChange(false)}
+              >
+                <Button.Text color="$white" fontSize={fontSizes.body}>
+                  キャンセル
+                </Button.Text>
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <Button
+                backgroundColor="$firebrick"
+                borderRadius={30}
+                paddingHorizontal={32}
+                marginHorizontal={16}
+                marginTop={16}
+                borderWidth={0}
+                onPress={() => onConfirm?.()}
+              >
+                <Button.Text color="$white" fontSize={fontSizes.body}>
+                  {buttonLabel}
+                </Button.Text>
+              </Button>
+            </AlertDialog.Action>
+          </XStack>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog>
+  );
+}

--- a/src/components/record/CategoryGrid.tsx
+++ b/src/components/record/CategoryGrid.tsx
@@ -1,0 +1,89 @@
+import { FlatList, Pressable } from 'react-native';
+import { YStack } from '@tamagui/stacks';
+import { SizableText } from '@tamagui/text';
+import { FontAwesome6 } from '@expo/vector-icons';
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+
+type Category = {
+  id: number;
+  name: string;
+};
+
+type Props = {
+  categories: Category[];
+  selectedCategoryId: number | null;
+  onSelect: (id: number) => void;
+};
+
+type CategoryStyle = {
+  icon: keyof typeof FontAwesome6.glyphMap;
+  color: string;
+};
+
+const CATEGORY_STYLE_MAP: Record<string, CategoryStyle> = {
+  フード:       { icon: 'bowl-food',       color: wanchoColors.sage },
+  おやつ:       { icon: 'bone',              color: wanchoColors.sandBeige },
+  医療費:       { icon: 'hospital',           color: wanchoColors.palePink },
+  トリミング:   { icon: 'scissors',             color: wanchoColors.lavender },
+  ペット保険:   { icon: 'shield-dog',  color: wanchoColors.paleBlue },
+  おもちゃ: { icon: 'soccer-ball',           color: wanchoColors.lavender },
+  日用品:       { icon: 'shirt',        color: wanchoColors.sandBeige },
+  ペットホテル: { icon: 'home',              color: wanchoColors.paleBlue },
+  その他:       { icon: 'ellipsis', color: wanchoColors.lightGray },
+};
+
+const DEFAULT_STYLE: CategoryStyle = {
+  icon: 'help-circle-outline',
+  color: wanchoColors.lightGray,
+};
+
+export default function CategoryGrid({ categories, selectedCategoryId, onSelect }: Props) {
+  return (
+    <FlatList
+      data={categories}
+      keyExtractor={(item) => String(item.id)}
+      numColumns={3}
+      scrollEnabled={false}
+      renderItem={({ item }) => {
+        const style = CATEGORY_STYLE_MAP[item.name] ?? DEFAULT_STYLE;
+        const isSelected = item.id === selectedCategoryId;
+
+        return (
+          <Pressable
+            onPress={() => onSelect(item.id)}
+            style={{ flex: 1, padding: 6 }}
+          >
+            <YStack
+              alignItems="center"
+              gap={6}
+              paddingVertical={12}
+              borderRadius={12}
+              borderWidth={2}
+              borderColor={isSelected ? '$sage' : 'transparent'}
+              backgroundColor={isSelected ? '$sandBeige' : '$lightGray'}
+            >
+              <YStack
+                width={44}
+                height={44}
+                borderRadius={22}
+                backgroundColor={style.color}
+                alignItems="center"
+                justifyContent="center"
+              >
+                <FontAwesome6 name={style.icon} size={22} color={wanchoColors.white} />
+              </YStack>
+              <SizableText
+                fontSize={fontSizes.caption}
+                color="$charcoal"
+                textAlign="center"
+                numberOfLines={2}
+              >
+                {item.name}
+              </SizableText>
+            </YStack>
+          </Pressable>
+        );
+      }}
+    />
+  );
+}

--- a/src/components/record/CategoryGrid.tsx
+++ b/src/components/record/CategoryGrid.tsx
@@ -4,6 +4,7 @@ import { SizableText } from '@tamagui/text';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import { Category } from '@/types/categories';
+import { CATEGORIES } from '@/constants/categories';
 
 type Props = {
   categories: Category[];
@@ -32,18 +33,21 @@ export default function CategoryGrid({ categories, selectedCategoryId, onSelect 
               paddingVertical={12}
               borderRadius={12}
               borderWidth={2}
-              borderColor={isSelected ? '$sage' : 'transparent'}
-              backgroundColor={isSelected ? '$sandBeige' : '$lightGray'}
+              borderColor={isSelected ? item.bgColor : 'transparent'}
+              backgroundColor={wanchoColors.lightGray}
             >
               <YStack
                 width={44}
                 height={44}
                 borderRadius={22}
-                backgroundColor={item.bgColor}
                 alignItems="center"
                 justifyContent="center"
               >
-                <FontAwesome6 name={item.icon as keyof typeof FontAwesome6.glyphMap} size={22} color={wanchoColors.greige} />
+                <FontAwesome6 
+                  name={item.icon as keyof typeof FontAwesome6.glyphMap} 
+                  size={32} 
+                  color={item.bgColor} 
+                />
               </YStack>
               <SizableText
                 fontSize={fontSizes.caption}

--- a/src/components/record/CategoryGrid.tsx
+++ b/src/components/record/CategoryGrid.tsx
@@ -3,38 +3,12 @@ import { YStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
-
-type Category = {
-  id: number;
-  name: string;
-};
+import { Category } from '@/types/categories';
 
 type Props = {
   categories: Category[];
   selectedCategoryId: number | null;
   onSelect: (id: number) => void;
-};
-
-type CategoryStyle = {
-  icon: keyof typeof FontAwesome6.glyphMap;
-  color: string;
-};
-
-const CATEGORY_STYLE_MAP: Record<string, CategoryStyle> = {
-  フード:       { icon: 'bowl-food',       color: wanchoColors.sage },
-  おやつ:       { icon: 'bone',              color: wanchoColors.sandBeige },
-  医療費:       { icon: 'hospital',           color: wanchoColors.palePink },
-  トリミング:   { icon: 'scissors',             color: wanchoColors.lavender },
-  ペット保険:   { icon: 'shield-dog',  color: wanchoColors.paleBlue },
-  おもちゃ: { icon: 'soccer-ball',           color: wanchoColors.lavender },
-  日用品:       { icon: 'shirt',        color: wanchoColors.sandBeige },
-  ペットホテル: { icon: 'home',              color: wanchoColors.paleBlue },
-  その他:       { icon: 'ellipsis', color: wanchoColors.lightGray },
-};
-
-const DEFAULT_STYLE: CategoryStyle = {
-  icon: 'help-circle-outline',
-  color: wanchoColors.lightGray,
 };
 
 export default function CategoryGrid({ categories, selectedCategoryId, onSelect }: Props) {
@@ -45,7 +19,6 @@ export default function CategoryGrid({ categories, selectedCategoryId, onSelect 
       numColumns={3}
       scrollEnabled={false}
       renderItem={({ item }) => {
-        const style = CATEGORY_STYLE_MAP[item.name] ?? DEFAULT_STYLE;
         const isSelected = item.id === selectedCategoryId;
 
         return (
@@ -66,11 +39,11 @@ export default function CategoryGrid({ categories, selectedCategoryId, onSelect 
                 width={44}
                 height={44}
                 borderRadius={22}
-                backgroundColor={style.color}
+                backgroundColor={item.bgColor}
                 alignItems="center"
                 justifyContent="center"
               >
-                <FontAwesome6 name={style.icon} size={22} color={wanchoColors.white} />
+                <FontAwesome6 name={item.icon as keyof typeof FontAwesome6.glyphMap} size={22} color={wanchoColors.greige} />
               </YStack>
               <SizableText
                 fontSize={fontSizes.caption}

--- a/src/components/record/SwipeableExpenseRow.tsx
+++ b/src/components/record/SwipeableExpenseRow.tsx
@@ -1,0 +1,134 @@
+import { TouchableOpacity } from 'react-native';
+import ReanimatedSwipeable, { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import { useRef } from 'react';
+import { YStack, XStack } from '@tamagui/stacks';
+import { SizableText } from '@tamagui/text';
+import { FontAwesome6 } from '@expo/vector-icons';
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+import { CATEGORIES } from '@/constants/categories';
+import { Expense } from '@/types/expense';
+
+type SwipeableRowProps = {
+  item: Expense;
+  onEdit: (item: Expense) => void;
+  onDelete: (item: Expense) => void;
+  showDate: boolean;
+}
+
+function formatAmount(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
+
+function formatDate(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  return `${Number(month)}/${Number(day)}`;
+}
+
+// 各費用リストの1行分のコンポーネント
+export const SwipeableExpenseRow = ({
+  item, 
+  onEdit, 
+  onDelete, 
+  showDate
+} : SwipeableRowProps) => {
+  const category = CATEGORIES.find((c) => c.id === item.categoryId);
+  const ref = useRef<SwipeableMethods | null>(null);
+
+  const handleEdit = (item: Expense) => {
+    ref.current?.close();
+    onEdit(item);
+  };
+
+  const handleDelete = (item: Expense) => {
+    ref.current?.close();
+    onDelete(item);
+  };
+
+  const renderRightActions = (item: Expense) => {
+    return (
+      <XStack>
+        <TouchableOpacity onPress={() => handleEdit(item)}>
+          <YStack
+            style={{
+              backgroundColor : wanchoColors.sage,
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72,
+              height: '100%',
+            }}
+          >
+            <FontAwesome6 name='edit' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
+          </YStack>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => handleDelete(item)}>
+          <YStack 
+            style={{
+              backgroundColor : wanchoColors.firebrick, 
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72, 
+              height: '100%'
+            }}
+          >
+            <FontAwesome6 name='trash-can' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>削除</SizableText>
+          </YStack>
+        </TouchableOpacity>
+      </XStack>
+    )
+  }; 
+
+  return (
+    <ReanimatedSwipeable
+      ref={ref}
+      renderRightActions={() => renderRightActions(item)}
+      overshootRight={false}
+    >
+      <XStack
+        paddingVertical={12}
+        paddingHorizontal={16}
+        backgroundColor="$white"
+        borderBottomWidth={1}
+        borderBottomColor="$lightGray"
+        alignItems="center"
+        gap={12}
+      >
+        <YStack
+          width={36}
+          height={36}
+          borderRadius={18}
+          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <FontAwesome6
+            name={(category?.icon ?? 'ellipsis') as any}
+            size={18}
+            color={wanchoColors.greige}
+          />
+        </YStack>
+        <YStack flex={1}>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {category?.name ?? 'その他'}
+          </SizableText>
+          <XStack gap={4}>
+          {showDate && (
+            <SizableText fontSize={fontSizes.caption} color="$greige">
+              {formatDate(item.date)}
+            </SizableText>
+          )}
+          {item.memo && (
+            <SizableText fontSize={fontSizes.caption} color="$greige">
+              {item.memo}
+            </SizableText>
+          )}
+          </XStack>
+        </YStack>
+        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+          {formatAmount(item.amount)}
+        </SizableText>
+      </XStack>
+    </ReanimatedSwipeable>
+  );
+};

--- a/src/components/record/SwipeableExpenseRow.tsx
+++ b/src/components/record/SwipeableExpenseRow.tsx
@@ -98,14 +98,15 @@ export const SwipeableExpenseRow = ({
           width={36}
           height={36}
           borderRadius={18}
-          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+          borderColor={category?.bgColor ?? wanchoColors.sage}
+          borderWidth={1} 
           alignItems="center"
           justifyContent="center"
         >
           <FontAwesome6
             name={(category?.icon ?? 'ellipsis') as any}
             size={18}
-            color={wanchoColors.greige}
+            color={category?.bgColor ?? wanchoColors.greige}
           />
         </YStack>
         <YStack flex={1}>

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,13 @@
+import { Category } from "@/types/categories";
+
+export const CATEGORIES: Category[] = [
+  { id: 1, name: 'フード' },
+  { id: 2, name: 'おやつ' },
+  { id: 3, name: '医療費' },
+  { id: 4, name: 'トリミング' },
+  { id: 5, name: 'ペット保険' },
+  { id: 6, name: 'おもちゃ' },
+  { id: 7, name: '日用品' },
+  { id: 8, name: 'ペットホテル' },
+  { id: 9, name: 'その他' },
+];

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,13 +1,14 @@
 import { Category } from "@/types/categories";
+import { wanchoColors } from "tamagui.config";
 
 export const CATEGORIES: Category[] = [
-  { id: 1, name: 'フード' },
-  { id: 2, name: 'おやつ' },
-  { id: 3, name: '医療費' },
-  { id: 4, name: 'トリミング' },
-  { id: 5, name: 'ペット保険' },
-  { id: 6, name: 'おもちゃ' },
-  { id: 7, name: '日用品' },
-  { id: 8, name: 'ペットホテル' },
-  { id: 9, name: 'その他' },
+  { id: 1, name: 'フード', icon: 'bowl-food', bgColor: wanchoColors.sage },
+  { id: 2, name: 'おやつ', icon: 'bone', bgColor: wanchoColors.sandBeige},
+  { id: 3, name: '医療費', icon: 'hospital', bgColor: wanchoColors.palePink},
+  { id: 4, name: 'トリミング', icon: 'scissors', bgColor: wanchoColors.lavender},
+  { id: 5, name: 'ペット保険', icon: 'shield-dog', bgColor: wanchoColors.paleBlue},
+  { id: 6, name: 'おもちゃ', icon: 'soccer-ball', bgColor: wanchoColors.mint },
+  { id: 7, name: '日用品', icon: 'shirt', bgColor: wanchoColors.camel },
+  { id: 8, name: 'ペットホテル', icon: 'house', bgColor:wanchoColors.mauve },
+  { id: 9, name: 'その他', icon: 'ellipsis', bgColor: wanchoColors.lightGray },
 ];

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -3,12 +3,12 @@ import { wanchoColors } from "tamagui.config";
 
 export const CATEGORIES: Category[] = [
   { id: 1, name: 'フード', icon: 'bowl-food', bgColor: wanchoColors.sage },
-  { id: 2, name: 'おやつ', icon: 'bone', bgColor: wanchoColors.sandBeige},
+  { id: 2, name: 'おやつ', icon: 'bone', bgColor: wanchoColors.taupe},
   { id: 3, name: '医療費', icon: 'hospital', bgColor: wanchoColors.palePink},
   { id: 4, name: 'トリミング', icon: 'scissors', bgColor: wanchoColors.lavender},
   { id: 5, name: 'ペット保険', icon: 'shield-dog', bgColor: wanchoColors.paleBlue},
   { id: 6, name: 'おもちゃ', icon: 'soccer-ball', bgColor: wanchoColors.mint },
   { id: 7, name: '日用品', icon: 'shirt', bgColor: wanchoColors.camel },
   { id: 8, name: 'ペットホテル', icon: 'house', bgColor:wanchoColors.mauve },
-  { id: 9, name: 'その他', icon: 'ellipsis', bgColor: wanchoColors.lightGray },
+  { id: 9, name: 'その他', icon: 'ellipsis', bgColor: wanchoColors.greige },
 ];

--- a/src/db/expenseRepository.ts
+++ b/src/db/expenseRepository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, like } from 'drizzle-orm';
 import { expenses } from '@/db/schema';
 import { db } from '@/db';
 import { NewExpense, UpdateExpense } from '@/types/expense';
@@ -6,6 +6,11 @@ import { NewExpense, UpdateExpense } from '@/types/expense';
 export const getExpenses = async () => {
   return await db.select().from(expenses);
 };
+
+// 1ヶ月ごとの費用抽出
+export const getExpensesByMonth = async (yearMonth: string) => {
+  return await db.select().from(expenses).where(like(expenses.date, `${yearMonth}-%`));
+}
 
 export const addExpense = async (input: NewExpense) => {
   const result = await db.insert(expenses).values(input).returning();

--- a/src/db/expenseRepository.ts
+++ b/src/db/expenseRepository.ts
@@ -9,6 +9,10 @@ export const getExpenses = async () => {
 
 // 1ヶ月ごとの費用抽出
 export const getExpensesByMonth = async (yearMonth: string) => {
+  // 日付け意識のバリデーションをチェック
+  if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+    throw new Error(`Invalid yearMonth format: ${yearMonth}`);
+  }
   return await db.select().from(expenses).where(like(expenses.date, `${yearMonth}-%`));
 }
 

--- a/src/navigation/RecordNavigator.tsx
+++ b/src/navigation/RecordNavigator.tsx
@@ -1,0 +1,33 @@
+import AllRecordsScreen from "@/screens/record/AllRecordsScreen";
+import RecordScreen from "@/screens/record/RecordScreen";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { wanchoColors } from "tamagui.config";
+
+export type RecordStackParamList = {
+  RecordMain: undefined;
+  AllRecords: undefined;
+}
+
+const Stack = createNativeStackNavigator<RecordStackParamList>();
+
+export default function RecordNavigator() {
+  return(
+    <Stack.Navigator screenOptions={{ headerShown: false}}>
+      <Stack.Screen 
+        name='RecordMain'
+        component={RecordScreen}
+      />
+      <Stack.Screen 
+        name='AllRecords'
+        component={AllRecordsScreen}
+        options={{
+          headerShown: true,
+          title:'',
+          headerBackTitle: '戻る',
+          headerStyle: { backgroundColor: wanchoColors.ivory },
+          headerTintColor: wanchoColors.sage,
+        }}
+      />
+    </Stack.Navigator>
+  )
+}

--- a/src/navigation/RecordNavigator.tsx
+++ b/src/navigation/RecordNavigator.tsx
@@ -1,7 +1,7 @@
 import AllRecordsScreen from "@/screens/record/AllRecordsScreen";
 import RecordScreen from "@/screens/record/RecordScreen";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { wanchoColors } from "tamagui.config";
+import { wanchoColors } from "../../tamagui.config";
 
 export type RecordStackParamList = {
   RecordMain: undefined;

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,9 +1,9 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import HomeScreen from '@/screens/home/HomeScreen';
-import RecordScreen from '@/screens/record/RecordScreen';
 import PlannerScreen from '@/screens/planner/PlannerScreen';
 import ReportScreen from '@/screens/report/ReportScreen';
 import SettingsScreen from '@/screens/settings/SettingsScreen';
+import RecordNavigator from './RecordNavigator';
 
 type TabParamList = {
   Home: undefined;
@@ -27,7 +27,7 @@ export default function TabNavigator() {
       />
       <Tab.Screen 
         name="Record"
-        component={RecordScreen} 
+        component={RecordNavigator} 
         options={{
           title: '記録',
         }}

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,7 +1,7 @@
 import { SectionList, Pressable, StyleSheet, TouchableOpacity } from 'react-native';
-import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import ReanimatedSwipeable, { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
 import { FontAwesome6 } from '@expo/vector-icons';
@@ -16,6 +16,12 @@ type Section = {
   title: string;
   data: Expense[];
 };
+
+type SwipeableRowProps = {
+  item: Expense;
+  onEdit: (item: Expense) => void;
+  onDelete: (item: Expense) => void;
+}
 
 function formatSectionDate(dateStr: string): string {
   const [year, month, day] = dateStr.split('-').map(Number);
@@ -46,6 +52,103 @@ function groupByDate(expenses: Expense[]): Section[] {
     }));
 }
 
+// 各費用リストの1行分のコンポーネント
+const SwipeableRow = ({item, onEdit, onDelete}: SwipeableRowProps) => {
+  const category = CATEGORIES.find((c) => c.id === item.categoryId);
+  const ref = useRef<SwipeableMethods | null>(null);
+
+  const handleEdit = (item: Expense) => {
+    ref.current?.close();
+    onEdit(item);
+  };
+
+  const handleDelete = (item: Expense) => {
+    ref.current?.close();
+    onDelete(item);
+  };
+
+  const renderRightActions = (item: Expense) => {
+    return (
+      <XStack>
+        <TouchableOpacity onPress={() => handleEdit(item)}>
+          <YStack
+            style={{
+              backgroundColor : wanchoColors.sage,
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72,
+              height: '100%',
+            }}
+          >
+            <FontAwesome6 name='edit' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
+          </YStack>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => handleDelete(item)}>
+          <YStack 
+            style={{
+              backgroundColor : wanchoColors.firebrick, 
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72, 
+              height: '100%'
+            }}
+          >
+            <FontAwesome6 name='trash-can' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>削除</SizableText>
+          </YStack>
+        </TouchableOpacity>
+      </XStack>
+    )
+  }; 
+
+  return (
+    <ReanimatedSwipeable
+      ref={ref}
+      renderRightActions={() => renderRightActions(item)}
+      overshootRight={false}
+    >
+      <XStack
+        paddingVertical={12}
+        paddingHorizontal={16}
+        backgroundColor="$white"
+        borderBottomWidth={1}
+        borderBottomColor="$lightGray"
+        alignItems="center"
+        gap={12}
+      >
+        <YStack
+          width={36}
+          height={36}
+          borderRadius={18}
+          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <FontAwesome6
+            name={(category?.icon ?? 'ellipsis') as any}
+            size={18}
+            color={wanchoColors.greige}
+          />
+        </YStack>
+        <YStack flex={1}>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {category?.name ?? 'その他'}
+          </SizableText>
+          {item.memo && (
+            <SizableText fontSize={fontSizes.caption} color="$greige">
+              {item.memo}
+            </SizableText>
+          )}
+        </YStack>
+        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+          {formatAmount(item.amount)}
+        </SizableText>
+      </XStack>
+    </ReanimatedSwipeable>
+  );
+};
+
 export default function AllRecordsScreen() {
   const { monthlyExpenses, deleteExpense } = useExpenseStore();
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
@@ -64,89 +167,6 @@ export default function AllRecordsScreen() {
       </SizableText>
     </YStack>
   );
-
-  const renderRightActions = (item: Expense) => {
-    return (
-      <XStack>
-        <TouchableOpacity onPress={() => setEditingExpense(item)}>
-          <YStack 
-            style={{
-              backgroundColor : wanchoColors.sage,
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 72,
-              height: '100%',
-            }}
-          >
-            <FontAwesome6 name='edit' size={20} color={wanchoColors.white} />
-            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
-          </YStack>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => setConfirmingItem(item)}>
-          <YStack 
-            style={{
-              backgroundColor : wanchoColors.firebrick, 
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 72, 
-              height: '100%'
-            }}
-          >
-            <FontAwesome6 name='trash-can' size={20} color={wanchoColors.white} />
-            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>削除</SizableText>
-          </YStack>
-        </TouchableOpacity>
-      </XStack>
-    )
-  };
-
-  const renderItem = ({ item }: { item: Expense }) => {
-    const category = CATEGORIES.find((c) => c.id === item.categoryId);
-    return (
-      <ReanimatedSwipeable
-        renderRightActions={() => renderRightActions(item)}
-        overshootRight={false}
-      >
-        <XStack
-          paddingVertical={12}
-          paddingHorizontal={16}
-          backgroundColor="$white"
-          borderBottomWidth={1}
-          borderBottomColor="$lightGray"
-          alignItems="center"
-          gap={12}
-        >
-          <YStack
-            width={36}
-            height={36}
-            borderRadius={18}
-            backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
-            alignItems="center"
-            justifyContent="center"
-          >
-            <FontAwesome6
-              name={(category?.icon ?? 'ellipsis') as any}
-              size={18}
-              color={wanchoColors.greige}
-            />
-          </YStack>
-          <YStack flex={1}>
-            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-              {category?.name ?? 'その他'}
-            </SizableText>
-            {item.memo && (
-              <SizableText fontSize={fontSizes.caption} color="$greige">
-                {item.memo}
-              </SizableText>
-            )}
-          </YStack>
-          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-            {formatAmount(item.amount)}
-          </SizableText>
-        </XStack>
-      </ReanimatedSwipeable>
-    );
-  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
@@ -197,7 +217,13 @@ export default function AllRecordsScreen() {
         <SectionList
           sections={sections}
           keyExtractor={(item) => String(item.id)}
-          renderItem={renderItem}
+          renderItem={({ item }) => (
+            <SwipeableRow
+              item={item}
+              onEdit={setEditingExpense}
+              onDelete={setConfirmingItem}
+            />
+          )}
           renderSectionHeader={renderSectionHeader}
           contentContainerStyle={styles.listContent}
           ListEmptyComponent={

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,4 +1,4 @@
-import { SectionList, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { SectionList, Pressable, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useState } from 'react';
 import { YStack, XStack } from '@tamagui/stacks';
@@ -108,12 +108,7 @@ export default function AllRecordsScreen() {
       <YStack flex={1} backgroundColor="$ivory">
 
         {/* カテゴリフィルタータグ */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.tagContainer}
-          style={{ flexGrow: 0 }}
-        >
+        <XStack flexWrap="wrap" paddingHorizontal={16} paddingVertical={12} gap={8}>
           <Pressable onPress={() => setSelectedCategoryId(null)}>
             <YStack
               paddingHorizontal={14}
@@ -122,7 +117,6 @@ export default function AllRecordsScreen() {
               borderWidth={1}
               borderColor={selectedCategoryId === null ? '$sage' : '$lightGray'}
               backgroundColor={selectedCategoryId === null ? '$sage' : '$white'}
-              marginRight={8}
             >
               <SizableText
                 fontSize={fontSizes.caption}
@@ -142,7 +136,6 @@ export default function AllRecordsScreen() {
                 borderWidth={1}
                 borderColor={selectedCategoryId === category.id ? '$sage' : '$lightGray'}
                 backgroundColor={selectedCategoryId === category.id ? '$sage' : '$white'}
-                marginRight={8}
               >
                 <SizableText
                   fontSize={fontSizes.caption}
@@ -150,10 +143,10 @@ export default function AllRecordsScreen() {
                 >
                   {category.name}
                 </SizableText>
-            </YStack>
+              </YStack>
             </Pressable>
           ))}
-        </ScrollView>
+        </XStack>
 
         {/* 支出一覧 */}
         <SectionList
@@ -179,10 +172,6 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: wanchoColors.ivory,
-  },
-  tagContainer: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
   },
   listContent: {
     paddingBottom: 32,

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -8,6 +8,7 @@ import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import { useExpenseStore } from '@/store/expenseStore';
 import { CATEGORIES } from '@/constants/categories';
 import { Expense } from '@/types/expense';
+import ExpenseFormModal from './ExpenseFormModal';
 
 type Section = {
   title: string;
@@ -46,6 +47,7 @@ function groupByDate(expenses: Expense[]): Section[] {
 export default function AllRecordsScreen() {
   const { monthlyExpenses } = useExpenseStore();
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   const filteredExpenses = selectedCategoryId
     ? monthlyExpenses.filter((e) => e.categoryId === selectedCategoryId)
@@ -99,6 +101,9 @@ export default function AllRecordsScreen() {
         <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
           {formatAmount(item.amount)}
         </SizableText>
+        <Pressable onPress={() => setEditingExpense(item)}>
+          <SizableText>Edit</SizableText>
+        </Pressable>
       </XStack>
     );
   };
@@ -163,6 +168,11 @@ export default function AllRecordsScreen() {
             </YStack>
           }
         />
+      <ExpenseFormModal 
+        visible={editingExpense !== null}
+        onClose={() => setEditingExpense(null)}
+        editingExpense={editingExpense}
+      />
       </YStack>
     </SafeAreaView>
   );

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,10 +1,9 @@
-import { SectionList, Pressable, StyleSheet, TouchableOpacity } from 'react-native';
-import ReanimatedSwipeable, { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import { SectionList, Pressable, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
-import { FontAwesome6 } from '@expo/vector-icons';
+import { SwipeableExpenseRow } from '../../components/record/SwipeableExpenseRow';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import { useExpenseStore } from '@/store/expenseStore';
 import { CATEGORIES } from '@/constants/categories';
@@ -17,19 +16,9 @@ type Section = {
   data: Expense[];
 };
 
-type SwipeableRowProps = {
-  item: Expense;
-  onEdit: (item: Expense) => void;
-  onDelete: (item: Expense) => void;
-}
-
 function formatSectionDate(dateStr: string): string {
   const [year, month, day] = dateStr.split('-').map(Number);
   return `${year}年${month}月${day}日`;
-}
-
-function formatAmount(amount: number): string {
-  return `¥${amount.toLocaleString()}`;
 }
 
 function groupByDate(expenses: Expense[]): Section[] {
@@ -51,103 +40,6 @@ function groupByDate(expenses: Expense[]): Section[] {
       data: grouped[date],
     }));
 }
-
-// 各費用リストの1行分のコンポーネント
-const SwipeableRow = ({item, onEdit, onDelete}: SwipeableRowProps) => {
-  const category = CATEGORIES.find((c) => c.id === item.categoryId);
-  const ref = useRef<SwipeableMethods | null>(null);
-
-  const handleEdit = (item: Expense) => {
-    ref.current?.close();
-    onEdit(item);
-  };
-
-  const handleDelete = (item: Expense) => {
-    ref.current?.close();
-    onDelete(item);
-  };
-
-  const renderRightActions = (item: Expense) => {
-    return (
-      <XStack>
-        <TouchableOpacity onPress={() => handleEdit(item)}>
-          <YStack
-            style={{
-              backgroundColor : wanchoColors.sage,
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 72,
-              height: '100%',
-            }}
-          >
-            <FontAwesome6 name='edit' size={20} color={wanchoColors.white} />
-            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
-          </YStack>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => handleDelete(item)}>
-          <YStack 
-            style={{
-              backgroundColor : wanchoColors.firebrick, 
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 72, 
-              height: '100%'
-            }}
-          >
-            <FontAwesome6 name='trash-can' size={20} color={wanchoColors.white} />
-            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>削除</SizableText>
-          </YStack>
-        </TouchableOpacity>
-      </XStack>
-    )
-  }; 
-
-  return (
-    <ReanimatedSwipeable
-      ref={ref}
-      renderRightActions={() => renderRightActions(item)}
-      overshootRight={false}
-    >
-      <XStack
-        paddingVertical={12}
-        paddingHorizontal={16}
-        backgroundColor="$white"
-        borderBottomWidth={1}
-        borderBottomColor="$lightGray"
-        alignItems="center"
-        gap={12}
-      >
-        <YStack
-          width={36}
-          height={36}
-          borderRadius={18}
-          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
-          alignItems="center"
-          justifyContent="center"
-        >
-          <FontAwesome6
-            name={(category?.icon ?? 'ellipsis') as any}
-            size={18}
-            color={wanchoColors.greige}
-          />
-        </YStack>
-        <YStack flex={1}>
-          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-            {category?.name ?? 'その他'}
-          </SizableText>
-          {item.memo && (
-            <SizableText fontSize={fontSizes.caption} color="$greige">
-              {item.memo}
-            </SizableText>
-          )}
-        </YStack>
-        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-          {formatAmount(item.amount)}
-        </SizableText>
-      </XStack>
-    </ReanimatedSwipeable>
-  );
-};
 
 export default function AllRecordsScreen() {
   const { monthlyExpenses, deleteExpense } = useExpenseStore();
@@ -218,10 +110,11 @@ export default function AllRecordsScreen() {
           sections={sections}
           keyExtractor={(item) => String(item.id)}
           renderItem={({ item }) => (
-            <SwipeableRow
+            <SwipeableExpenseRow
               item={item}
               onEdit={setEditingExpense}
               onDelete={setConfirmingItem}
+              showDate={false}
             />
           )}
           renderSectionHeader={renderSectionHeader}

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,4 +1,5 @@
-import { SectionList, Pressable, StyleSheet } from 'react-native';
+import { SectionList, Pressable, StyleSheet, TouchableOpacity } from 'react-native';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useState } from 'react';
 import { YStack, XStack } from '@tamagui/stacks';
@@ -45,7 +46,7 @@ function groupByDate(expenses: Expense[]): Section[] {
 }
 
 export default function AllRecordsScreen() {
-  const { monthlyExpenses } = useExpenseStore();
+  const { monthlyExpenses, deleteExpense } = useExpenseStore();
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
@@ -62,49 +63,86 @@ export default function AllRecordsScreen() {
     </YStack>
   );
 
+  const renderRightActions = (item: Expense) => {
+    return (
+      <XStack>
+        <TouchableOpacity onPress={() => setEditingExpense(item)}>
+          <YStack 
+            style={{
+              backgroundColor : wanchoColors.sage,
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72,
+              height: '100%',
+            }}
+          >
+            <FontAwesome6 name='edit' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
+          </YStack>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => deleteExpense(item.id)}>
+          <YStack 
+            style={{
+              backgroundColor : wanchoColors.firebrick, 
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 72, 
+              height: '100%'
+            }}
+          >
+            <FontAwesome6 name='trash-can' size={20} color={wanchoColors.white} />
+            <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>削除</SizableText>
+          </YStack>
+        </TouchableOpacity>
+      </XStack>
+    )
+  };
+
   const renderItem = ({ item }: { item: Expense }) => {
     const category = CATEGORIES.find((c) => c.id === item.categoryId);
     return (
-      <XStack
-        paddingVertical={12}
-        paddingHorizontal={16}
-        backgroundColor="$white"
-        borderBottomWidth={1}
-        borderBottomColor="$lightGray"
-        alignItems="center"
-        gap={12}
+      <ReanimatedSwipeable
+        renderRightActions={() => renderRightActions(item)}
+        overshootRight={false}
       >
-        <YStack
-          width={36}
-          height={36}
-          borderRadius={18}
-          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+        <XStack
+          paddingVertical={12}
+          paddingHorizontal={16}
+          backgroundColor="$white"
+          borderBottomWidth={1}
+          borderBottomColor="$lightGray"
           alignItems="center"
-          justifyContent="center"
+          gap={12}
         >
-          <FontAwesome6
-            name={(category?.icon ?? 'ellipsis') as any}
-            size={18}
-            color={wanchoColors.greige}
-          />
-        </YStack>
-        <YStack flex={1}>
-          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-            {category?.name ?? 'その他'}
-          </SizableText>
-          {item.memo && (
-            <SizableText fontSize={fontSizes.caption} color="$greige">
-              {item.memo}
+          <YStack
+            width={36}
+            height={36}
+            borderRadius={18}
+            backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <FontAwesome6
+              name={(category?.icon ?? 'ellipsis') as any}
+              size={18}
+              color={wanchoColors.greige}
+            />
+          </YStack>
+          <YStack flex={1}>
+            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+              {category?.name ?? 'その他'}
             </SizableText>
-          )}
-        </YStack>
-        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-          {formatAmount(item.amount)}
-        </SizableText>
-        <Pressable onPress={() => setEditingExpense(item)}>
-          <SizableText>Edit</SizableText>
-        </Pressable>
-      </XStack>
+            {item.memo && (
+              <SizableText fontSize={fontSizes.caption} color="$greige">
+                {item.memo}
+              </SizableText>
+            )}
+          </YStack>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {formatAmount(item.amount)}
+          </SizableText>
+        </XStack>
+      </ReanimatedSwipeable>
     );
   };
 

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,9 +1,190 @@
-import { View, Text } from 'react-native';
+import { SectionList, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useState } from 'react';
+import { YStack, XStack } from '@tamagui/stacks';
+import { SizableText } from '@tamagui/text';
+import { FontAwesome6 } from '@expo/vector-icons';
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+import { useExpenseStore } from '@/store/expenseStore';
+import { CATEGORIES } from '@/constants/categories';
+import { Expense } from '@/types/expense';
+
+type Section = {
+  title: string;
+  data: Expense[];
+};
+
+function formatSectionDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return `${year}年${month}月${day}日`;
+}
+
+function formatAmount(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
+
+function groupByDate(expenses: Expense[]): Section[] {
+  // 日付でグループ分けをする。
+  const grouped = expenses.reduce<Record<string, Expense[]>>((acc, expense) => {
+    const key = expense.date;
+    if (!acc[key]) {
+      acc[key] = []; // 未登録のキー(日付)があれば空配列を準備
+    }
+    acc[key].push(expense);
+    return acc;
+  }, {});
+  
+  // SectionList用の配列を渡す関数を実装する
+  return Object.keys(grouped)
+    .sort((a,b) => b.localeCompare(a))
+    .map((date) => ({
+      title: date,
+      data: grouped[date],
+    }));
+}
 
 export default function AllRecordsScreen() {
+  const { monthlyExpenses } = useExpenseStore();
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+
+  const filteredExpenses = selectedCategoryId
+    ? monthlyExpenses.filter((e) => e.categoryId === selectedCategoryId)
+    : monthlyExpenses;
+
+  const sections = groupByDate(filteredExpenses);
+  const renderSectionHeader = ({ section }: { section: Section }) => (
+    <YStack paddingVertical={8} paddingHorizontal={16} backgroundColor="$ivory">
+      <SizableText fontSize={fontSizes.footnote} color="$greige" fontWeight="bold">
+        {formatSectionDate(section.title)}
+      </SizableText>
+    </YStack>
+  );
+
+  const renderItem = ({ item }: { item: Expense }) => {
+    const category = CATEGORIES.find((c) => c.id === item.categoryId);
+    return (
+      <XStack
+        paddingVertical={12}
+        paddingHorizontal={16}
+        backgroundColor="$white"
+        borderBottomWidth={1}
+        borderBottomColor="$lightGray"
+        alignItems="center"
+        gap={12}
+      >
+        <YStack
+          width={36}
+          height={36}
+          borderRadius={18}
+          backgroundColor={category?.bgColor ?? wanchoColors.lightGray}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <FontAwesome6
+            name={(category?.icon ?? 'ellipsis') as any}
+            size={18}
+            color={wanchoColors.greige}
+          />
+        </YStack>
+        <YStack flex={1}>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {category?.name ?? 'その他'}
+          </SizableText>
+          {item.memo && (
+            <SizableText fontSize={fontSizes.caption} color="$greige">
+              {item.memo}
+            </SizableText>
+          )}
+        </YStack>
+        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+          {formatAmount(item.amount)}
+        </SizableText>
+      </XStack>
+    );
+  };
+
   return (
-    <View style={{ flex: 1}}>
-      <Text>全てを見る</Text>
-    </View>
+    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+      <YStack flex={1} backgroundColor="$ivory">
+
+        {/* カテゴリフィルタータグ */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.tagContainer}
+          style={{ flexGrow: 0 }}
+        >
+          <Pressable onPress={() => setSelectedCategoryId(null)}>
+            <YStack
+              paddingHorizontal={14}
+              paddingVertical={6}
+              borderRadius={20}
+              borderWidth={1}
+              borderColor={selectedCategoryId === null ? '$sage' : '$lightGray'}
+              backgroundColor={selectedCategoryId === null ? '$sage' : '$white'}
+              marginRight={8}
+            >
+              <SizableText
+                fontSize={fontSizes.caption}
+                color={selectedCategoryId === null ? '$white' : '$greige'}
+              >
+                すべて
+              </SizableText>
+            </YStack>
+          </Pressable>
+
+          {CATEGORIES.map((category) => (
+            <Pressable key={category.id} onPress={() => setSelectedCategoryId(category.id)}>
+              <YStack
+                paddingHorizontal={14}
+                paddingVertical={6}
+                borderRadius={20}
+                borderWidth={1}
+                borderColor={selectedCategoryId === category.id ? '$sage' : '$lightGray'}
+                backgroundColor={selectedCategoryId === category.id ? '$sage' : '$white'}
+                marginRight={8}
+              >
+                <SizableText
+                  fontSize={fontSizes.caption}
+                  color={selectedCategoryId === category.id ? '$white' : '$greige'}
+                >
+                  {category.name}
+                </SizableText>
+            </YStack>
+            </Pressable>
+          ))}
+        </ScrollView>
+
+        {/* 支出一覧 */}
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={
+            <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={60}>
+              <SizableText fontSize={fontSizes.body} color="$greige">
+                記録がありません
+              </SizableText>
+            </YStack>
+          }
+        />
+      </YStack>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: wanchoColors.ivory,
+  },
+  tagContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  listContent: {
+    paddingBottom: 32,
+  },
+});

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -10,6 +10,7 @@ import { useExpenseStore } from '@/store/expenseStore';
 import { CATEGORIES } from '@/constants/categories';
 import { Expense } from '@/types/expense';
 import ExpenseFormModal from './ExpenseFormModal';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 type Section = {
   title: string;
@@ -49,6 +50,7 @@ export default function AllRecordsScreen() {
   const { monthlyExpenses, deleteExpense } = useExpenseStore();
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [confirmingItem, setConfirmingItem] = useState<Expense | null>(null);
 
   const filteredExpenses = selectedCategoryId
     ? monthlyExpenses.filter((e) => e.categoryId === selectedCategoryId)
@@ -80,7 +82,7 @@ export default function AllRecordsScreen() {
             <SizableText style={{color: wanchoColors.white, fontSize: fontSizes.footnote}}>編集</SizableText>
           </YStack>
         </TouchableOpacity>
-        <TouchableOpacity onPress={() => deleteExpense(item.id)}>
+        <TouchableOpacity onPress={() => setConfirmingItem(item)}>
           <YStack 
             style={{
               backgroundColor : wanchoColors.firebrick, 
@@ -206,11 +208,21 @@ export default function AllRecordsScreen() {
             </YStack>
           }
         />
-      <ExpenseFormModal 
-        visible={editingExpense !== null}
-        onClose={() => setEditingExpense(null)}
-        editingExpense={editingExpense}
-      />
+        <ExpenseFormModal
+          visible={editingExpense !== null}
+          onClose={() => setEditingExpense(null)}
+          editingExpense={editingExpense}
+        />
+        <ConfirmDialog
+          open={confirmingItem !== null}
+          onOpenChange={(open) => { if (!open) setConfirmingItem(null); }}
+          title="本当に削除しますか？"
+          buttonLabel="削除する"
+          onConfirm={() => {
+            if (confirmingItem) deleteExpense(confirmingItem.id); 
+            setConfirmingItem(null);
+          }}
+        />
       </YStack>
     </SafeAreaView>
   );

--- a/src/screens/record/AllRecordsScreen.tsx
+++ b/src/screens/record/AllRecordsScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function AllRecordsScreen() {
+  return (
+    <View style={{ flex: 1}}>
+      <Text>全てを見る</Text>
+    </View>
+  );
+}

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -1,6 +1,6 @@
 import { Modal, ScrollView, Pressable, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -16,10 +16,12 @@ import RNDateTimePicker from '@react-native-community/datetimepicker';
 import { usePetStore } from '@/store/petStore';
 import { useExpenseStore } from '@/store/expenseStore';
 import ErrorAlertDialog from '@/components/ErrorAlertDialog';
+import { Expense } from '@/types/expense';
 
-type Props = {  
+type Props = {
   visible: boolean;
   onClose: () => void;
+  editingExpense?: Expense | null;
 };
 
 const expenseSchema = z.object({
@@ -31,10 +33,10 @@ const expenseSchema = z.object({
 
 type ExpenseSchema = z.infer<typeof expenseSchema>;
 
-export default function ExpenseFormModal({ visible, onClose }: Props) {
+export default function ExpenseFormModal({ visible, onClose, editingExpense }: Props) {
   const [show, setShow] = useState(false);
   const pets = usePetStore((state) => state.pets);
-  const { addExpense, isLoading, error } = useExpenseStore();
+  const { addExpense, updateExpense, isLoading, error } = useExpenseStore();
   const [showError, setShowError] = useState(false);
 
   const { control, handleSubmit, formState: { errors }, reset } = useForm<ExpenseSchema>({
@@ -46,17 +48,25 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
     }
   });
 
-  const onSubmit = async (data: ExpenseSchema) => {
-    const petId = pets[0]?.id;
-    if(!petId) {
-      setShowError(true);
-      return;
+  useEffect(() => {
+    if(visible) {
+      editingExpense ? reset({...editingExpense, date: new Date(editingExpense.date + 'T00:00:00') }) : reset()
     }
-    await addExpense({
-      ...data,
-      date: data.date.toISOString().split('T')[0],
-      petId: petId
-    })
+  },[visible, editingExpense]);
+
+  const onSubmit = async (data: ExpenseSchema) => {
+    const formattedDate = data.date.toISOString().split('T')[0];
+
+    if(editingExpense) {
+      await updateExpense(editingExpense.id, {...data, date: formattedDate})
+    } else {
+      const petId = pets[0]?.id;
+      if(!petId) {
+        setShowError(true);
+        return;
+      }
+      await addExpense({...data, date: formattedDate, petId})
+    }
     const { error: storeError } = useExpenseStore.getState();
     if (storeError) {
       setShowError(true);
@@ -86,7 +96,7 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
             borderBottomColor="$lightGray"
           >
             <SizableText fontSize={fontSizes.heading2} fontWeight="bold" color="$charcoal">
-              支出を追加
+              {editingExpense ? '支出を編集' : '支出を追加'}
             </SizableText>
             <Pressable onPress={onClose}>
               <Ionicons name="close" size={24} color={wanchoColors.charcoal} />

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 const expenseSchema = z.object({
   categoryId: z.int(),
-  amount: z.coerce.number<number>().int().min(1,'0円以上を入力してください'),
+  amount: z.coerce.number<number>().int().min(1,'1円以上を入力してください'),
   date: z.date(),
   memo: z.string().nullable()
 })
@@ -125,7 +125,7 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
                       <RNDateTimePicker
                         value={value}
                         display="inline"
-                        locale="jp"
+                        locale="ja"
                         onChange={(_, selectedDate) => {
                           if (selectedDate) onChange(selectedDate);
                           setShow(false);

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 const expenseSchema = z.object({
   categoryId: z.int(),
-  amount: z.int().min(1, '0円以上入力してください'),
+  amount: z.coerce.number<number>().int().min(1,'0円以上を入力してください'),
   date: z.date(),
   memo: z.string().nullable()
 })
@@ -167,7 +167,7 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
                   alignItems="center"
                   gap={4}
                 >
-                  <Controller 
+                  <Controller
                     control={control}
                     name="amount"
                     render={({ field: { onChange, value }}) => 
@@ -177,7 +177,7 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
                         placeholder="0"
                         keyboardType="numeric"
                         value={value != null ? String(value) : ''}
-                        onChangeText={(text) => onChange(text === '' ? undefined : parseInt(text, 10))}
+                        onChangeText={onChange}
                         fontSize={fontSizes.body}
                         color="$charcoal"
                         paddingVertical={12}
@@ -250,7 +250,7 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
               </YStack>
               {/* 保存ボタン */}
               {/* TODO: isLoading 中はローディング表示に切り替える */}
-              <YStack paddingHorizontal={16} paddingBottom={16}>
+              <YStack paddingHorizontal={16} paddingVertical={16}>
                 <Button
                   backgroundColor="$sage"
                   borderRadius={30}

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -85,7 +85,6 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
     >
       <SafeAreaView style={styles.safeArea}>
           <YStack flex={1} backgroundColor="$ivory">
-
             {/* ヘッダー */}
             <XStack
               paddingHorizontal={16}

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { Modal, SafeAreaView, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { YStack, XStack } from '@tamagui/stacks';
+import { SizableText } from '@tamagui/text';
+import { Button } from '@tamagui/button';
+import { Input } from '@tamagui/input';
+import { Ionicons } from '@expo/vector-icons';
+import CategoryGrid from '@/components/record/CategoryGrid';
+import { CATEGORIES } from '../../constants/categories';
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export default function ExpenseFormModal({ visible, onClose }: Props) {
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [date, setDate] = useState('');
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+
+  // TODO: React Hook Form + Zod でバリデーションを追加する
+  // TODO: 保存時に useExpenseStore().addExpense() を呼ぶ
+  const handleSubmit = () => {
+    console.log({ selectedCategoryId, date, amount, memo });
+    onClose();
+  };
+
+  // TODO: @react-native-community/datetimepicker を使った日付選択に切り替える
+  const handleDatePress = () => {
+    console.log('日付ピッカーを開く');
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <YStack flex={1} backgroundColor="$ivory">
+
+          {/* ヘッダー */}
+          <XStack
+            paddingHorizontal={16}
+            paddingVertical={12}
+            justifyContent="space-between"
+            alignItems="center"
+            borderBottomWidth={1}
+            borderBottomColor="$lightGray"
+          >
+            <SizableText fontSize={fontSizes.heading2} fontWeight="bold" color="$charcoal">
+              支出を追加
+            </SizableText>
+            <Pressable onPress={onClose}>
+              <Ionicons name="close" size={24} color={wanchoColors.charcoal} />
+            </Pressable>
+          </XStack>
+
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <YStack gap={24}>
+
+              {/* カテゴリ選択 */}
+              <YStack gap={8}>
+                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                  カテゴリ
+                </SizableText>
+                <CategoryGrid
+                  categories={CATEGORIES}
+                  selectedCategoryId={selectedCategoryId}
+                  onSelect={setSelectedCategoryId}
+                />
+              </YStack>
+
+              {/* 日付 */}
+              <YStack gap={8}>
+                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                  日付
+                </SizableText>
+                {/* TODO: Pressable → DateTimePicker を開く実装に切り替える */}
+                <Pressable onPress={handleDatePress}>
+                  <XStack
+                    backgroundColor="$white"
+                    borderRadius={8}
+                    padding={12}
+                    alignItems="center"
+                    justifyContent="space-between"
+                  >
+                    <SizableText fontSize={fontSizes.body} color={date ? '$charcoal' : '$greige'}>
+                      {date || 'YYYY/MM/DD'}
+                    </SizableText>
+                    <Ionicons name="calendar-outline" size={20} color={wanchoColors.greige} />
+                  </XStack>
+                </Pressable>
+              </YStack>
+
+              {/* 金額 */}
+              <YStack gap={8}>
+                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                  金額
+                </SizableText>
+                <XStack
+                  backgroundColor="$white"
+                  borderRadius={8}
+                  paddingHorizontal={12}
+                  alignItems="center"
+                  gap={4}
+                >
+                  {/* TODO: バリデーション（数字のみ・必須）を追加する */}
+                  <Input
+                    flex={1}
+                    unstyled
+                    placeholder="0"
+                    keyboardType="numeric"
+                    value={amount}
+                    onChangeText={setAmount}
+                    fontSize={fontSizes.body}
+                    color="$charcoal"
+                    paddingVertical={12}
+                  />
+                  <SizableText fontSize={fontSizes.body} color="$greige">
+                    円
+                  </SizableText>
+                </XStack>
+              </YStack>
+
+              {/* メモ */}
+              <YStack gap={8}>
+                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                  メモ（任意）
+                </SizableText>
+                <Input
+                  unstyled
+                  placeholder="メモを入力"
+                  value={memo}
+                  onChangeText={setMemo}
+                  fontSize={fontSizes.body}
+                  color="$charcoal"
+                  backgroundColor="$white"
+                  borderRadius={8}
+                  padding={12}
+                  multiline
+                  numberOfLines={3}
+                />
+              </YStack>
+
+            </YStack>
+          </ScrollView>
+
+          {/* 保存ボタン */}
+          {/* TODO: isLoading 中はローディング表示に切り替える */}
+          <YStack paddingHorizontal={16} paddingBottom={16}>
+            <Button
+              backgroundColor="$sage"
+              borderRadius={30}
+              borderWidth={0}
+              pressStyle={{ opacity: 0.8 }}
+              onPress={handleSubmit}
+            >
+              <Button.Text fontSize={fontSizes.body} color="$white" fontWeight="bold">
+                保存
+              </Button.Text>
+            </Button>
+          </YStack>
+
+        </YStack>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: wanchoColors.ivory,
+  },
+  scrollContent: {
+    padding: 16,
+  },
+});

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -8,6 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 import CategoryGrid from '@/components/record/CategoryGrid';
 import { CATEGORIES } from '../../constants/categories';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
+import RNDateTimePicker from '@react-native-community/datetimepicker';
 
 type Props = {
   visible: boolean;
@@ -16,9 +17,10 @@ type Props = {
 
 export default function ExpenseFormModal({ visible, onClose }: Props) {
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
-  const [date, setDate] = useState('');
+  const [date, setDate] = useState(new Date());
   const [amount, setAmount] = useState('');
   const [memo, setMemo] = useState('');
+  const [show, setShow] = useState(false);
 
   // TODO: React Hook Form + Zod でバリデーションを追加する
   // TODO: 保存時に useExpenseStore().addExpense() を呼ぶ
@@ -27,9 +29,9 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
     onClose();
   };
 
-  // TODO: @react-native-community/datetimepicker を使った日付選択に切り替える
-  const handleDatePress = () => {
-    console.log('日付ピッカーを開く');
+  const pickDate = (selectedDate?: Date) => {
+    if (selectedDate) setDate(selectedDate);
+    setShow(false);
   };
 
   return (
@@ -79,8 +81,16 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
                 <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
                   日付
                 </SizableText>
-                {/* TODO: Pressable → DateTimePicker を開く実装に切り替える */}
-                <Pressable onPress={handleDatePress}>
+                {/* TODO: 日付選択の実装 */}
+                {show && 
+                  <RNDateTimePicker
+                    value={date}
+                    display="inline"
+                    locale="jp"
+                    onChange={(_, selectedDate) => pickDate(selectedDate)}
+                  />
+                }
+                <Pressable onPress={() => setShow(true)}>
                   <XStack
                     backgroundColor="$white"
                     borderRadius={8}
@@ -88,8 +98,8 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
                     alignItems="center"
                     justifyContent="space-between"
                   >
-                    <SizableText fontSize={fontSizes.body} color={date ? '$charcoal' : '$greige'}>
-                      {date || 'YYYY/MM/DD'}
+                    <SizableText fontSize={fontSizes.body} color="$charcoal">
+                      {`${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`}
                     </SizableText>
                     <Ionicons name="calendar-outline" size={20} color={wanchoColors.greige} />
                   </XStack>

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -1,5 +1,9 @@
+import { Modal, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useState } from 'react';
-import { Modal, SafeAreaView, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
 import { Button } from '@tamagui/button';
@@ -10,28 +14,36 @@ import { CATEGORIES } from '../../constants/categories';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import RNDateTimePicker from '@react-native-community/datetimepicker';
 
-type Props = {
+type Props = {  
   visible: boolean;
   onClose: () => void;
 };
 
+const expenseSchema = z.object({
+  category_id: z.int(),
+  amount: z.int().min(1, '0円以上入力してください'),
+  date: z.date(),
+  memo: z.string().nullable()
+})
+
+type ExpenseSchema = z.infer<typeof expenseSchema>;
+
 export default function ExpenseFormModal({ visible, onClose }: Props) {
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
-  const [date, setDate] = useState(new Date());
-  const [amount, setAmount] = useState('');
-  const [memo, setMemo] = useState('');
   const [show, setShow] = useState(false);
 
   // TODO: React Hook Form + Zod でバリデーションを追加する
+  const { control, handleSubmit, formState: { errors } } = useForm<ExpenseSchema>({
+    resolver: zodResolver(expenseSchema),
+    defaultValues: {
+      date: new Date(),
+      memo: null,
+    }
+  })
+  console.log('Errors:', errors)
   // TODO: 保存時に useExpenseStore().addExpense() を呼ぶ
-  const handleSubmit = () => {
-    console.log({ selectedCategoryId, date, amount, memo });
-    onClose();
-  };
-
-  const pickDate = (selectedDate?: Date) => {
-    if (selectedDate) setDate(selectedDate);
-    setShow(false);
+  const onSubmit = (data) => {
+    console.log(`data:`,data);
+    // onClose();
   };
 
   return (
@@ -65,45 +77,74 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
             <YStack gap={24}>
 
               {/* カテゴリ選択 */}
-              <YStack gap={8}>
-                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-                  カテゴリ
+              <Controller
+                control={control}
+                name="category_id"
+                render={({ field: { value, onChange }}) => 
+                <YStack gap={8}>
+                  <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                    カテゴリ
+                  </SizableText>
+                  <CategoryGrid
+                    categories={CATEGORIES}
+                    selectedCategoryId={value ?? null}
+                    onSelect={onChange}
+                  />
+                </YStack>
+                } 
+              />
+              <YStack>
+              {errors.category_id && 
+                <SizableText fontSize={fontSizes.footnote} color="$firebrick">
+                  カテゴリを選択してください
                 </SizableText>
-                <CategoryGrid
-                  categories={CATEGORIES}
-                  selectedCategoryId={selectedCategoryId}
-                  onSelect={setSelectedCategoryId}
-                />
+              }
               </YStack>
 
               {/* 日付 */}
-              <YStack gap={8}>
-                <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-                  日付
-                </SizableText>
-                {/* TODO: 日付選択の実装 */}
-                {show && 
-                  <RNDateTimePicker
-                    value={date}
-                    display="inline"
-                    locale="jp"
-                    onChange={(_, selectedDate) => pickDate(selectedDate)}
-                  />
-                }
-                <Pressable onPress={() => setShow(true)}>
-                  <XStack
-                    backgroundColor="$white"
-                    borderRadius={8}
-                    padding={12}
-                    alignItems="center"
-                    justifyContent="space-between"
-                  >
-                    <SizableText fontSize={fontSizes.body} color="$charcoal">
-                      {`${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`}
+              <Controller
+                control={control}
+                name="date"
+                render={({ field: {value, onChange}}) => 
+                  <YStack gap={8}>
+                    <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                      日付
                     </SizableText>
-                    <Ionicons name="calendar-outline" size={20} color={wanchoColors.greige} />
-                  </XStack>
-                </Pressable>
+                    {/* TODO: 日付選択の実装 */}
+                    {show &&
+                      <RNDateTimePicker
+                        value={value}
+                        display="inline"
+                        locale="jp"
+                        onChange={(_, selectedDate) => {
+                          if (selectedDate) onChange(selectedDate);
+                          setShow(false);
+                        }}
+                      />
+                    }
+                    <Pressable onPress={() => setShow(true)}>
+                      <XStack
+                        backgroundColor="$white"
+                        borderRadius={8}
+                        padding={12}
+                        alignItems="center"
+                        justifyContent="space-between"
+                      >
+                        <SizableText fontSize={fontSizes.body} color="$charcoal">
+                          {`${value.getFullYear()}/${String(value.getMonth() + 1).padStart(2, '0')}/${String(value.getDate()).padStart(2, '0')}`}
+                        </SizableText>
+                        <Ionicons name="calendar-outline" size={20} color={wanchoColors.greige} />
+                      </XStack>
+                    </Pressable>
+                  </YStack>
+                }
+              />
+              <YStack>
+              {errors.date && 
+                <SizableText fontSize={fontSizes.footnote} color="$firebrick">
+                  日付を選択してください
+                </SizableText>
+              }
               </YStack>
 
               {/* 金額 */}
@@ -118,22 +159,34 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
                   alignItems="center"
                   gap={4}
                 >
-                  {/* TODO: バリデーション（数字のみ・必須）を追加する */}
-                  <Input
-                    flex={1}
-                    unstyled
-                    placeholder="0"
-                    keyboardType="numeric"
-                    value={amount}
-                    onChangeText={setAmount}
-                    fontSize={fontSizes.body}
-                    color="$charcoal"
-                    paddingVertical={12}
+                  <Controller 
+                    control={control}
+                    name="amount"
+                    render={({ field: { onChange, value }}) => 
+                      <Input
+                        flex={1}
+                        unstyled
+                        placeholder="0"
+                        keyboardType="numeric"
+                        value={value != null ? String(value) : ''}
+                        onChangeText={(text) => onChange(text === '' ? undefined : parseInt(text, 10))}
+                        fontSize={fontSizes.body}
+                        color="$charcoal"
+                        paddingVertical={12}
+                      />
+                    }
                   />
                   <SizableText fontSize={fontSizes.body} color="$greige">
                     円
                   </SizableText>
                 </XStack>
+              </YStack>
+              <YStack>
+              {errors.amount && 
+                <SizableText fontSize={fontSizes.footnote} color="$firebrick">
+                  金額を入力してください。
+                </SizableText>
+              }
               </YStack>
 
               {/* メモ */}
@@ -141,21 +194,26 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
                 <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
                   メモ（任意）
                 </SizableText>
-                <Input
-                  unstyled
-                  placeholder="メモを入力"
-                  value={memo}
-                  onChangeText={setMemo}
-                  fontSize={fontSizes.body}
-                  color="$charcoal"
-                  backgroundColor="$white"
-                  borderRadius={8}
-                  padding={12}
-                  multiline
-                  numberOfLines={3}
+                <Controller 
+                  control={control}
+                  name="memo"
+                  render={({ field: { onChange, value }}) => 
+                    <Input
+                      unstyled
+                      placeholder="メモを入力"
+                      value={value ?? ''} 
+                      onChangeText={onChange}
+                      fontSize={fontSizes.body}
+                      color="$charcoal"
+                      backgroundColor="$white"
+                      borderRadius={8}
+                      padding={12}
+                      multiline
+                      numberOfLines={3}
+                    />
+                  }
                 />
               </YStack>
-
             </YStack>
           </ScrollView>
 
@@ -167,7 +225,7 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
               borderRadius={30}
               borderWidth={0}
               pressStyle={{ opacity: 0.8 }}
-              onPress={handleSubmit}
+              onPress={handleSubmit(onSubmit)}
             >
               <Button.Text fontSize={fontSizes.body} color="$white" fontWeight="bold">
                 保存

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -55,7 +55,10 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
   },[visible, editingExpense]);
 
   const onSubmit = async (data: ExpenseSchema) => {
-    const formattedDate = data.date.toISOString().split('T')[0];
+    const year = data.date.getFullYear();
+    const month = String(data.date.getMonth() + 1).padStart(2, '0');
+    const day = String(data.date.getDate()).padStart(2,'0');
+    const formattedDate = `${year}-${month}-${day}`;
 
     if(editingExpense) {
       await updateExpense(editingExpense.id, {...data, date: formattedDate})

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -84,53 +84,31 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
       onRequestClose={onClose}
     >
       <SafeAreaView style={styles.safeArea}>
-        <YStack flex={1} backgroundColor="$ivory">
+          <YStack flex={1} backgroundColor="$ivory">
 
-          {/* ヘッダー */}
-          <XStack
-            paddingHorizontal={16}
-            paddingVertical={12}
-            justifyContent="space-between"
-            alignItems="center"
-            borderBottomWidth={1}
-            borderBottomColor="$lightGray"
-          >
-            <SizableText fontSize={fontSizes.heading2} fontWeight="bold" color="$charcoal">
-              {editingExpense ? '支出を編集' : '支出を追加'}
-            </SizableText>
-            <Pressable onPress={onClose}>
-              <Ionicons name="close" size={24} color={wanchoColors.charcoal} />
-            </Pressable>
-          </XStack>
+            {/* ヘッダー */}
+            <XStack
+              paddingHorizontal={16}
+              paddingVertical={12}
+              justifyContent="space-between"
+              alignItems="center"
+              borderBottomWidth={1}
+              borderBottomColor="$lightGray"
+            >
+              <SizableText fontSize={fontSizes.heading2} fontWeight="bold" color="$charcoal">
+                {editingExpense ? '支出を編集' : '支出を追加'}
+              </SizableText>
+              <Pressable onPress={onClose}>
+                <Ionicons name="close" size={24} color={wanchoColors.charcoal} />
+              </Pressable>
+            </XStack>
 
-          <ScrollView contentContainerStyle={styles.scrollContent}>
-            <YStack gap={24}>
-
-              {/* カテゴリ選択 */}
-              <Controller
-                control={control}
-                name="categoryId"
-                render={({ field: { value, onChange }}) => 
-                <YStack gap={8}>
-                  <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-                    カテゴリ
-                  </SizableText>
-                  <CategoryGrid
-                    categories={CATEGORIES}
-                    selectedCategoryId={value ?? null}
-                    onSelect={onChange}
-                  />
-                </YStack>
-                } 
-              />
-              <YStack>
-              {errors.categoryId && 
-                <SizableText fontSize={fontSizes.footnote} color="$firebrick">
-                  カテゴリを選択してください
-                </SizableText>
-              }
-              </YStack>
-
+            <ScrollView
+              style={{ flex: 1 }}
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+              automaticallyAdjustKeyboardInsets
+            >
               {/* 日付 */}
               <Controller
                 control={control}
@@ -218,6 +196,31 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
                 </SizableText>
               }
               </YStack>
+              <YStack gap={24}>
+                {/* カテゴリ選択 */}
+                <Controller
+                  control={control}
+                  name="categoryId"
+                  render={({ field: { value, onChange }}) => 
+                  <YStack gap={8}>
+                    <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+                      カテゴリ
+                    </SizableText>
+                    <CategoryGrid
+                      categories={CATEGORIES}
+                      selectedCategoryId={value ?? null}
+                      onSelect={onChange}
+                    />
+                  </YStack>
+                  } 
+                />
+                <YStack>
+                {errors.categoryId && 
+                  <SizableText fontSize={fontSizes.footnote} color="$firebrick">
+                    カテゴリを選択してください
+                  </SizableText>
+                }
+              </YStack>
 
               {/* メモ */}
               <YStack gap={8}>
@@ -244,32 +247,32 @@ export default function ExpenseFormModal({ visible, onClose, editingExpense }: P
                   }
                 />
               </YStack>
-            </YStack>
-          </ScrollView>
+              </YStack>
+              {/* 保存ボタン */}
+              {/* TODO: isLoading 中はローディング表示に切り替える */}
+              <YStack paddingHorizontal={16} paddingBottom={16}>
+                <Button
+                  backgroundColor="$sage"
+                  borderRadius={30}
+                  borderWidth={0}
+                  pressStyle={{ opacity: 0.8 }}
+                  onPress={handleSubmit(onSubmit)}
+                  disabled={isLoading === true}
+                >
+                  <Button.Text fontSize={fontSizes.body} color="$white" fontWeight="bold">
+                    {isLoading ? "保存中..." : "保存" }
+                  </Button.Text>
+                </Button>
+              </YStack>
+            </ScrollView>
 
-          {/* 保存ボタン */}
-          {/* TODO: isLoading 中はローディング表示に切り替える */}
-          <YStack paddingHorizontal={16} paddingBottom={16}>
-            <Button
-              backgroundColor="$sage"
-              borderRadius={30}
-              borderWidth={0}
-              pressStyle={{ opacity: 0.8 }}
-              onPress={handleSubmit(onSubmit)}
-              disabled={isLoading === true}
-            >
-              <Button.Text fontSize={fontSizes.body} color="$white" fontWeight="bold">
-                {isLoading ? "保存中..." : "保存" }
-              </Button.Text>
-            </Button>
+            <ErrorAlertDialog
+              open={showError}
+              onOpenChange={setShowError}
+              title="エラーが発生しました"
+              description={error}
+            />
           </YStack>
-          <ErrorAlertDialog
-            open={showError}
-            onOpenChange={setShowError}
-            title="エラーが発生しました"
-            description={error}
-          />
-        </YStack>
       </SafeAreaView>
     </Modal>
   );
@@ -282,5 +285,6 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     padding: 16,
+    paddingBottom: 32,
   },
 });

--- a/src/screens/record/ExpenseFormModal.tsx
+++ b/src/screens/record/ExpenseFormModal.tsx
@@ -13,6 +13,9 @@ import CategoryGrid from '@/components/record/CategoryGrid';
 import { CATEGORIES } from '../../constants/categories';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import RNDateTimePicker from '@react-native-community/datetimepicker';
+import { usePetStore } from '@/store/petStore';
+import { useExpenseStore } from '@/store/expenseStore';
+import ErrorAlertDialog from '@/components/ErrorAlertDialog';
 
 type Props = {  
   visible: boolean;
@@ -20,7 +23,7 @@ type Props = {
 };
 
 const expenseSchema = z.object({
-  category_id: z.int(),
+  categoryId: z.int(),
   amount: z.int().min(1, '0円以上入力してください'),
   date: z.date(),
   memo: z.string().nullable()
@@ -30,20 +33,37 @@ type ExpenseSchema = z.infer<typeof expenseSchema>;
 
 export default function ExpenseFormModal({ visible, onClose }: Props) {
   const [show, setShow] = useState(false);
+  const pets = usePetStore((state) => state.pets);
+  const { addExpense, isLoading, error } = useExpenseStore();
+  const [showError, setShowError] = useState(false);
 
-  // TODO: React Hook Form + Zod でバリデーションを追加する
-  const { control, handleSubmit, formState: { errors } } = useForm<ExpenseSchema>({
+  const { control, handleSubmit, formState: { errors }, reset } = useForm<ExpenseSchema>({
     resolver: zodResolver(expenseSchema),
     defaultValues: {
+      categoryId: undefined,
       date: new Date(),
       memo: null,
     }
-  })
-  console.log('Errors:', errors)
-  // TODO: 保存時に useExpenseStore().addExpense() を呼ぶ
-  const onSubmit = (data) => {
-    console.log(`data:`,data);
-    // onClose();
+  });
+
+  const onSubmit = async (data: ExpenseSchema) => {
+    const petId = pets[0]?.id;
+    if(!petId) {
+      setShowError(true);
+      return;
+    }
+    await addExpense({
+      ...data,
+      date: data.date.toISOString().split('T')[0],
+      petId: petId
+    })
+    const { error: storeError } = useExpenseStore.getState();
+    if (storeError) {
+      setShowError(true);
+      return;
+    }
+    reset();
+    onClose();
   };
 
   return (
@@ -79,7 +99,7 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
               {/* カテゴリ選択 */}
               <Controller
                 control={control}
-                name="category_id"
+                name="categoryId"
                 render={({ field: { value, onChange }}) => 
                 <YStack gap={8}>
                   <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
@@ -94,7 +114,7 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
                 } 
               />
               <YStack>
-              {errors.category_id && 
+              {errors.categoryId && 
                 <SizableText fontSize={fontSizes.footnote} color="$firebrick">
                   カテゴリを選択してください
                 </SizableText>
@@ -226,13 +246,19 @@ export default function ExpenseFormModal({ visible, onClose }: Props) {
               borderWidth={0}
               pressStyle={{ opacity: 0.8 }}
               onPress={handleSubmit(onSubmit)}
+              disabled={isLoading === true}
             >
               <Button.Text fontSize={fontSizes.body} color="$white" fontWeight="bold">
-                保存
+                {isLoading ? "保存中..." : "保存" }
               </Button.Text>
             </Button>
           </YStack>
-
+          <ErrorAlertDialog
+            open={showError}
+            onOpenChange={setShowError}
+            title="エラーが発生しました"
+            description={error}
+          />
         </YStack>
       </SafeAreaView>
     </Modal>

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -3,8 +3,9 @@ import { FlatList, Pressable, StyleSheet } from 'react-native';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
 import { Button } from '@tamagui/button';
-import AntDesign from '@expo/vector-icons/AntDesign';
+import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
+import ExpenseFormModal from './ExpenseFormModal';
 
 type DummyExpense = {
   id: number;
@@ -113,13 +114,13 @@ export default function RecordScreen() {
         alignItems="center"
       >
         <Pressable onPress={() => setSelectedMonth(shiftMonth(selectedMonth, -1))}>
-          <AntDesign name="arrow-left" size={24} color={wanchoColors.charcoal} />
+          <FontAwesome6 name="arrow-left" size={24} color={wanchoColors.charcoal} />
         </Pressable>
         <SizableText fontSize={fontSizes.heading1} fontWeight="bold" color="$charcoal">
           {formatMonth(selectedMonth)}
         </SizableText>
         <Pressable onPress={() => setSelectedMonth(shiftMonth(selectedMonth, 1))}>
-          <AntDesign name="arrow-right"size={24} color={wanchoColors.charcoal} />
+          <FontAwesome6 name="arrow-right"size={24} color={wanchoColors.charcoal} />
         </Pressable>
       </XStack>
 
@@ -193,8 +194,14 @@ export default function RecordScreen() {
         pressStyle={{ opacity: 0.8 }}
         onPress={() => setModalVisible(true)}
       >
-        <AntDesign name="plus" size={20} color={wanchoColors.white} />
+        <FontAwesome6 name="add" size={22} color={wanchoColors.white} />
       </Button>
+
+      {/* 支出追加モーダル */}
+      <ExpenseFormModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+      />
     </YStack>
   );
 }

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -7,9 +7,10 @@ import { Button } from '@tamagui/button';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import ExpenseFormModal from './ExpenseFormModal';
+import { SwipeableExpenseRow } from '@/components/record/SwipeableExpenseRow';
+import ConfirmDialog from '@/components/ConfirmDialog';
 import { useExpenseStore } from '@/store/expenseStore';
 import { Expense } from '@/types/expense';
-import { CATEGORIES } from '@/constants/categories';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RecordStackParamList } from '@/navigation/RecordNavigator';
 
@@ -26,86 +27,28 @@ function shiftMonth(yearMonth: string, delta: number): string {
   return `${y}-${m}`;
 }
 
-function formatDate(dateStr: string): string {
-  const [, month, day] = dateStr.split('-');
-  return `${Number(month)}/${Number(day)}`;
-}
-
 function formatAmount(amount: number): string {
   return `¥${amount.toLocaleString()}`;
 }
 
-
 export default function RecordScreen() {
-  const [modalVisible, setModalVisible] = useState(false);
   const { 
     fetchExpensesByMonth,
     monthlyExpenses, 
     selectedMonth, 
-    setSelectedMonth 
+    setSelectedMonth,
+    deleteExpense
   } = useExpenseStore();  
   const expenses = monthlyExpenses;
   const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
   const navigation = useNavigation<NativeStackNavigationProp<RecordStackParamList, 'RecordMain'>>();
+  const [editingExpense, setEditExpense] = useState<Expense | null>(null);
+  const [confirmingItem, setConfirmingItem] = useState<Expense | null>(null);
+  const [ModalVisible, setModalVisible] = useState<boolean>(false);
   
   useEffect(() => {
     fetchExpensesByMonth(selectedMonth);
   }, [selectedMonth]);
-
-  const renderExpenseItem = ({ item }: { item: Expense }) => {
-    const category = CATEGORIES.find((c) => c.id === item.categoryId)
-    return (
-      <Pressable onPress={() => {}}>
-        <XStack
-          paddingVertical={12}
-          paddingHorizontal={16}
-          backgroundColor="$white"
-          borderRadius={12}
-          marginBottom={8}
-          alignItems="center"
-          gap={12}
-        >
-          {/* カテゴリアイコン（仮: 丸背景） */}
-          <YStack
-            width={40}
-            height={40}
-            borderRadius={20}
-            backgroundColor={category?.bgColor}
-            alignItems="center"
-            justifyContent="center"
-          >
-            <SizableText fontSize={fontSizes.caption} color="$white">
-              <FontAwesome6 name={category?.icon} size={20} />
-            </SizableText>
-          </YStack>
-
-          {/* カテゴリ名・メモ */}
-          <YStack flex={1}>
-            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-              {category?.name}
-            </SizableText>
-            <XStack gap={4}>
-              <SizableText fontSize={fontSizes.caption} color="$greige">
-                {formatDate(item.date)}
-              </SizableText>
-              {item.memo && (
-                <SizableText fontSize={fontSizes.caption} color="$greige">
-                  {item.memo}
-                </SizableText>
-              )}
-            </XStack>
-          </YStack>
-
-          {/* 金額・日付 */}
-          <YStack alignItems="flex-end">
-            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-              {formatAmount(item.amount)}
-            </SizableText>
-          </YStack>
-        </XStack>
-      </Pressable>
-    )
-  };
 
   return (
     <YStack flex={1} backgroundColor="$ivory">
@@ -173,7 +116,14 @@ export default function RecordScreen() {
       <FlatList
         data={expenses}
         keyExtractor={(item) => String(item.id)}
-        renderItem={renderExpenseItem}
+        renderItem={({item}) => (
+          <SwipeableExpenseRow
+            item={item}
+            onEdit={setEditExpense}
+            onDelete={setConfirmingItem}
+            showDate={true} 
+          />
+        )}
         contentContainerStyle={styles.listContent}
         ListEmptyComponent={
           <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={60}>
@@ -202,8 +152,23 @@ export default function RecordScreen() {
 
       {/* 支出追加モーダル */}
       <ExpenseFormModal
-        visible={modalVisible}
-        onClose={() => setModalVisible(false)}
+        visible={ModalVisible || editingExpense !== null}
+        onClose={() => {
+          setModalVisible(false);
+          setEditExpense(null);
+        }}
+        editingExpense={editingExpense}
+      />
+      {/* 削除確認用のModal */}
+      <ConfirmDialog 
+        open={confirmingItem !== null}
+        onOpenChange={(open) => {if (!open) setConfirmingItem(null); }}
+        title='本当に削除しますか？'
+        buttonLabel='削除する'
+        onConfirm={() => {
+          if (confirmingItem) deleteExpense(confirmingItem.id);
+          setConfirmingItem(null);
+        }}
       />
     </YStack>
   );

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -66,7 +66,7 @@ export default function RecordScreen() {
           {formatMonth(selectedMonth)}
         </SizableText>
         <Pressable onPress={() => setSelectedMonth(shiftMonth(selectedMonth, 1))}>
-          <FontAwesome6 name="arrow-right"size={24} color={wanchoColors.charcoal} />
+          <FontAwesome6 name="arrow-right" size={24} color={wanchoColors.charcoal} />
         </Pressable>
       </XStack>
 

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { FlatList, Pressable, StyleSheet } from 'react-native';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
+import { useNavigation } from '@react-navigation/native';
 import { Button } from '@tamagui/button';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
@@ -9,6 +10,8 @@ import ExpenseFormModal from './ExpenseFormModal';
 import { useExpenseStore } from '@/store/expenseStore';
 import { Expense } from '@/types/expense';
 import { CATEGORIES } from '@/constants/categories';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RecordStackParamList } from '@/navigation/RecordNavigator';
 
 function formatMonth(yearMonth: string): string {
   const [year, month] = yearMonth.split('-').map(Number);
@@ -40,11 +43,10 @@ export default function RecordScreen() {
     monthlyExpenses, 
     selectedMonth, 
     setSelectedMonth 
-  } = useExpenseStore();
-  
+  } = useExpenseStore();  
   const expenses = monthlyExpenses;
-  console.log(expenses)
   const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+  const navigation = useNavigation<NativeStackNavigationProp<RecordStackParamList, 'RecordMain'>>();
   
   useEffect(() => {
     fetchExpensesByMonth(selectedMonth);
@@ -160,7 +162,7 @@ export default function RecordScreen() {
         >
           最近の支出
         </SizableText>
-        <Pressable onPress={() => {}}>
+        <Pressable onPress={() => navigation.navigate('AllRecords')}>
           <SizableText fontSize={fontSizes.footnote} color="$sage" fontWeight="bold">
             全て見る →
           </SizableText>

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FlatList, Pressable, StyleSheet } from 'react-native';
 import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
@@ -6,20 +6,9 @@ import { Button } from '@tamagui/button';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
 import ExpenseFormModal from './ExpenseFormModal';
-
-type DummyExpense = {
-  id: number;
-  categoryName: string;
-  amount: number;
-  date: string;
-  memo: string | null;
-};
-
-const DUMMY_EXPENSES: DummyExpense[] = [
-  { id: 1, categoryName: 'フード', amount: 3500, date: '2026-05-10', memo: 'ドッグフード' },
-  { id: 2, categoryName: '医療費', amount: 8000, date: '2026-05-05', memo: 'ワクチン接種' },
-  { id: 3, categoryName: 'おやつ', amount: 1200, date: '2026-05-01', memo: null },
-];
+import { useExpenseStore } from '@/store/expenseStore';
+import { Expense } from '@/types/expense';
+import { CATEGORIES } from '@/constants/categories';
 
 function formatMonth(yearMonth: string): string {
   const [year, month] = yearMonth.split('-').map(Number);
@@ -43,66 +32,78 @@ function formatAmount(amount: number): string {
   return `¥${amount.toLocaleString()}`;
 }
 
+
 export default function RecordScreen() {
-  const today = new Date();
-  const initialMonth = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
-  const [selectedMonth, setSelectedMonth] = useState(initialMonth);
   const [modalVisible, setModalVisible] = useState(false);
-
-  const expenses = DUMMY_EXPENSES;
+  const { 
+    fetchExpensesByMonth,
+    monthlyExpenses, 
+    selectedMonth, 
+    setSelectedMonth 
+  } = useExpenseStore();
+  
+  const expenses = monthlyExpenses;
+  console.log(expenses)
   const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+  
+  useEffect(() => {
+    fetchExpensesByMonth(selectedMonth);
+  }, [selectedMonth]);
 
-  const renderExpenseItem = ({ item }: { item: DummyExpense }) => (
-    <Pressable onPress={() => {}}>
-      <XStack
-        paddingVertical={12}
-        paddingHorizontal={16}
-        backgroundColor="$white"
-        borderRadius={12}
-        marginBottom={8}
-        alignItems="center"
-        gap={12}
-      >
-        {/* カテゴリアイコン（仮: 丸背景） */}
-        <YStack
-          width={40}
-          height={40}
-          borderRadius={20}
-          backgroundColor="$sage"
+  const renderExpenseItem = ({ item }: { item: Expense }) => {
+    const category = CATEGORIES.find((c) => c.id === item.categoryId)
+    return (
+      <Pressable onPress={() => {}}>
+        <XStack
+          paddingVertical={12}
+          paddingHorizontal={16}
+          backgroundColor="$white"
+          borderRadius={12}
+          marginBottom={8}
           alignItems="center"
-          justifyContent="center"
+          gap={12}
         >
-          <SizableText fontSize={fontSizes.caption} color="$white">
-            {item.categoryName[0]}
-          </SizableText>
-        </YStack>
-
-        {/* カテゴリ名・メモ */}
-        <YStack flex={1}>
-          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-            {item.categoryName}
-          </SizableText>
-          <XStack gap={4}>
-            <SizableText fontSize={fontSizes.caption} color="$greige">
-              {formatDate(item.date)}
+          {/* カテゴリアイコン（仮: 丸背景） */}
+          <YStack
+            width={40}
+            height={40}
+            borderRadius={20}
+            backgroundColor={category?.bgColor}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <SizableText fontSize={fontSizes.caption} color="$white">
+              <FontAwesome6 name={category?.icon} size={20} />
             </SizableText>
-            {item.memo && (
-              <SizableText fontSize={fontSizes.caption} color="$greige">
-                {item.memo}
-              </SizableText>
-            )}
-          </XStack>
-        </YStack>
+          </YStack>
 
-        {/* 金額・日付 */}
-        <YStack alignItems="flex-end">
-          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-            {formatAmount(item.amount)}
-          </SizableText>
-        </YStack>
-      </XStack>
-    </Pressable>
-  );
+          {/* カテゴリ名・メモ */}
+          <YStack flex={1}>
+            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+              {category?.name}
+            </SizableText>
+            <XStack gap={4}>
+              <SizableText fontSize={fontSizes.caption} color="$greige">
+                {formatDate(item.date)}
+              </SizableText>
+              {item.memo && (
+                <SizableText fontSize={fontSizes.caption} color="$greige">
+                  {item.memo}
+                </SizableText>
+              )}
+            </XStack>
+          </YStack>
+
+          {/* 金額・日付 */}
+          <YStack alignItems="flex-end">
+            <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+              {formatAmount(item.amount)}
+            </SizableText>
+          </YStack>
+        </XStack>
+      </Pressable>
+    )
+  };
 
   return (
     <YStack flex={1} backgroundColor="$ivory">

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -1,17 +1,207 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { FlatList, Pressable, StyleSheet } from 'react-native';
+import { YStack, XStack } from '@tamagui/stacks';
+import { SizableText } from '@tamagui/text';
+import { Button } from '@tamagui/button';
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+
+type DummyExpense = {
+  id: number;
+  categoryName: string;
+  amount: number;
+  date: string;
+  memo: string | null;
+};
+
+const DUMMY_EXPENSES: DummyExpense[] = [
+  { id: 1, categoryName: 'フード', amount: 3500, date: '2026-05-10', memo: 'ドッグフード' },
+  { id: 2, categoryName: '医療費', amount: 8000, date: '2026-05-05', memo: 'ワクチン接種' },
+  { id: 3, categoryName: 'おやつ', amount: 1200, date: '2026-05-01', memo: null },
+];
+
+function formatMonth(yearMonth: string): string {
+  const [year, month] = yearMonth.split('-').map(Number);
+  return `${year}年${month}月`;
+}
+
+function shiftMonth(yearMonth: string, delta: number): string {
+  const [year, month] = yearMonth.split('-').map(Number);
+  const d = new Date(year, month - 1 + delta, 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function formatDate(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  return `${Number(month)}/${Number(day)}`;
+}
+
+function formatAmount(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
 
 export default function RecordScreen() {
+  const today = new Date();
+  const initialMonth = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+  const [selectedMonth, setSelectedMonth] = useState(initialMonth);
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const expenses = DUMMY_EXPENSES;
+  const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+
+  const renderExpenseItem = ({ item }: { item: DummyExpense }) => (
+    <Pressable onPress={() => {}}>
+      <XStack
+        paddingVertical={12}
+        paddingHorizontal={16}
+        backgroundColor="$white"
+        borderRadius={12}
+        marginBottom={8}
+        alignItems="center"
+        gap={12}
+      >
+        {/* カテゴリアイコン（仮: 丸背景） */}
+        <YStack
+          width={40}
+          height={40}
+          borderRadius={20}
+          backgroundColor="$sage"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <SizableText fontSize={fontSizes.caption} color="$white">
+            {item.categoryName[0]}
+          </SizableText>
+        </YStack>
+
+        {/* カテゴリ名・メモ */}
+        <YStack flex={1}>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {item.categoryName}
+          </SizableText>
+          <XStack gap={4}>
+            <SizableText fontSize={fontSizes.caption} color="$greige">
+              {formatDate(item.date)}
+            </SizableText>
+            {item.memo && (
+              <SizableText fontSize={fontSizes.caption} color="$greige">
+                {item.memo}
+              </SizableText>
+            )}
+          </XStack>
+        </YStack>
+
+        {/* 金額・日付 */}
+        <YStack alignItems="flex-end">
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {formatAmount(item.amount)}
+          </SizableText>
+        </YStack>
+      </XStack>
+    </Pressable>
+  );
+
   return (
-    <View style={styles.container}>
-      <Text>記録</Text>
-    </View>
+    <YStack flex={1} backgroundColor="$ivory">
+      {/* 月切り替え */}
+      <XStack
+        paddingHorizontal={24}
+        paddingVertical={16}
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <Pressable onPress={() => setSelectedMonth(shiftMonth(selectedMonth, -1))}>
+          <AntDesign name="arrow-left" size={24} color={wanchoColors.charcoal} />
+        </Pressable>
+        <SizableText fontSize={fontSizes.heading1} fontWeight="bold" color="$charcoal">
+          {formatMonth(selectedMonth)}
+        </SizableText>
+        <Pressable onPress={() => setSelectedMonth(shiftMonth(selectedMonth, 1))}>
+          <AntDesign name="arrow-right"size={24} color={wanchoColors.charcoal} />
+        </Pressable>
+      </XStack>
+
+      {/* 合計金額 */}
+      <YStack
+        marginHorizontal={16}
+        padding={16}
+        backgroundColor="$white"
+        borderRadius={12}
+        marginBottom={24}
+        gap={4}
+      >
+        <SizableText fontSize={fontSizes.footnote} color="$greige">
+          今月の合計
+        </SizableText>
+        <SizableText 
+          fontSize={fontSizes.display}
+          lineHeight={fontSizes.display * 1.5}
+          fontWeight="bold"
+          color="$charcoal"
+        >
+          {formatAmount(totalAmount)}
+        </SizableText>
+      </YStack>
+
+      {/* 最近の支出・全て見る */}
+      <XStack 
+        justifyContent="space-between" 
+        paddingHorizontal={16} 
+        marginBottom={8}
+      >
+        <SizableText
+          fontSize={fontSizes.title}
+          lineHeight={fontSizes.title * 1.5}
+          color="$charcoal"
+        >
+          最近の支出
+        </SizableText>
+        <Pressable onPress={() => {}}>
+          <SizableText fontSize={fontSizes.footnote} color="$sage" fontWeight="bold">
+            全て見る →
+          </SizableText>
+        </Pressable>
+      </XStack>
+
+      {/* 支出一覧 */}
+      <FlatList
+        data={expenses}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderExpenseItem}
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={
+          <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={60}>
+            <SizableText fontSize={fontSizes.body} color="$greige">
+              記録がありません
+            </SizableText>
+          </YStack>
+        }
+      />
+
+      {/* FAB */}
+      <Button
+        position="absolute"
+        bottom={24}
+        right={24}
+        width={56}
+        height={56}
+        borderRadius={28}
+        backgroundColor="$sage"
+        borderWidth={0}
+        pressStyle={{ opacity: 0.8 }}
+        onPress={() => setModalVisible(true)}
+      >
+        <AntDesign name="plus" size={20} color={wanchoColors.white} />
+      </Button>
+    </YStack>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 96,
   },
 });

--- a/src/screens/record/RecordScreen.tsx
+++ b/src/screens/record/RecordScreen.tsx
@@ -39,8 +39,10 @@ export default function RecordScreen() {
     setSelectedMonth,
     deleteExpense
   } = useExpenseStore();  
-  const expenses = monthlyExpenses;
-  const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+  const totalAmount = monthlyExpenses.reduce((sum, e) => sum + e.amount, 0);
+  const recentExpenses = [...monthlyExpenses]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, 5);
   const navigation = useNavigation<NativeStackNavigationProp<RecordStackParamList, 'RecordMain'>>();
   const [editingExpense, setEditExpense] = useState<Expense | null>(null);
   const [confirmingItem, setConfirmingItem] = useState<Expense | null>(null);
@@ -114,7 +116,7 @@ export default function RecordScreen() {
 
       {/* 支出一覧 */}
       <FlatList
-        data={expenses}
+        data={recentExpenses}
         keyExtractor={(item) => String(item.id)}
         renderItem={({item}) => (
           <SwipeableExpenseRow

--- a/src/store/expenseStore.ts
+++ b/src/store/expenseStore.ts
@@ -22,9 +22,13 @@ type ExpenseActions = {
 export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => {
   // 月別データの再取得をして月別データも更新する
   const refreshMonthlyExpenses = async () => {
-    const { selectedMonth } = useExpenseStore.getState();
-    const monthlyData = await getExpensesByMonth(selectedMonth);
-    set({ monthlyExpenses: monthlyData });
+    try {
+      const { selectedMonth } = useExpenseStore.getState();
+      const monthlyData = await getExpensesByMonth(selectedMonth);
+      set({ monthlyExpenses: monthlyData });
+    } catch (error) {
+      set({error: '更新に失敗しました'});
+    }
   };
 
   return {

--- a/src/store/expenseStore.ts
+++ b/src/store/expenseStore.ts
@@ -1,15 +1,19 @@
 import { create } from 'zustand';
 import { Expense, NewExpense, UpdateExpense } from '@/types/expense';
-import { getExpenses, addExpense, updateExpense, deleteExpense } from '@/db/expenseRepository';
+import { getExpenses, addExpense, updateExpense, deleteExpense, getExpensesByMonth } from '@/db/expenseRepository';
 
 type ExpenseState = {
   expenses: Expense[];
+  monthlyExpenses: Expense[];
+  selectedMonth: string;
   isLoading: boolean;
   error: string | null;
 };
 
 type ExpenseActions = {
   fetchExpenses: () => Promise<void>;
+  fetchExpensesByMonth: (yearMonth: string) => Promise<void>;
+  setSelectedMonth: (yearMonth: string) => void;
   addExpense: (input: NewExpense) => Promise<void>;
   updateExpense: (id: number, input: UpdateExpense) => Promise<void>;
   deleteExpense: (id: number) => Promise<void>;
@@ -17,6 +21,8 @@ type ExpenseActions = {
 
 export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => ({
   expenses: [],
+  monthlyExpenses:[],
+  selectedMonth: new Date().toISOString().slice(0,7),
   isLoading: false,
   error: null,
 
@@ -32,11 +38,35 @@ export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => ({
     }
   },
 
+  // 1ヶ月分の支出を抽出するAction
+  fetchExpensesByMonth: async (yearMonth: string) => {
+    set({ isLoading: true, error: null});
+    try {
+      const data = await getExpensesByMonth(yearMonth);
+      set({ monthlyExpenses: data});
+    } catch(e) {
+      set({ error: '支出の取得に失敗しました'});
+    } finally {
+      set({ isLoading: false});
+    }
+  },
+
+  // 月を選択するAction
+  setSelectedMonth: (yearMonth: string) => {
+    set({ selectedMonth: yearMonth });
+  },
+
   addExpense: async (input) => {
     set({ isLoading: true, error: null });
     try {
       const newExpense = await addExpense(input);
+      // 全期間のstateに費用を追加する
       set((state) => ({ expenses: [...state.expenses, newExpense] }));
+
+      // 月別データの再取得をして月別データも更新する
+      const { selectedMonth } = useExpenseStore.getState();
+      const monthlyData = await getExpensesByMonth(selectedMonth);
+      set({ monthlyExpenses: monthlyData });
     } catch (e) {
       set({ error: '支出の追加に失敗しました' });
     } finally {

--- a/src/store/expenseStore.ts
+++ b/src/store/expenseStore.ts
@@ -19,86 +19,95 @@ type ExpenseActions = {
   deleteExpense: (id: number) => Promise<void>;
 };
 
-export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => ({
-  expenses: [],
-  monthlyExpenses:[],
-  selectedMonth: new Date().toISOString().slice(0,7),
-  isLoading: false,
-  error: null,
+export const useExpenseStore = create<ExpenseState & ExpenseActions>((set) => {
+  // 月別データの再取得をして月別データも更新する
+  const refreshMonthlyExpenses = async () => {
+    const { selectedMonth } = useExpenseStore.getState();
+    const monthlyData = await getExpensesByMonth(selectedMonth);
+    set({ monthlyExpenses: monthlyData });
+  };
 
-  fetchExpenses: async () => {
-    set({ isLoading: true, error: null});
-    try {
-      const data = await getExpenses();
-      set({ expenses: data });
-    } catch (e) {
-      set({ error: '支出の取得に失敗しました'});
-    } finally {
-      set({ isLoading: false});
-    }
-  },
+  return {
+    expenses: [],
+    monthlyExpenses:[],
+    selectedMonth: new Date().toISOString().slice(0,7),
+    isLoading: false,
+    error: null,
 
-  // 1ヶ月分の支出を抽出するAction
-  fetchExpensesByMonth: async (yearMonth: string) => {
-    set({ isLoading: true, error: null});
-    try {
-      const data = await getExpensesByMonth(yearMonth);
-      set({ monthlyExpenses: data});
-    } catch(e) {
-      set({ error: '支出の取得に失敗しました'});
-    } finally {
-      set({ isLoading: false});
-    }
-  },
+    fetchExpenses: async () => {
+      set({ isLoading: true, error: null});
+      try {
+        const data = await getExpenses();
+        set({ expenses: data });
+      } catch (e) {
+        set({ error: '支出の取得に失敗しました'});
+      } finally {
+        set({ isLoading: false});
+      }
+    },
 
-  // 月を選択するAction
-  setSelectedMonth: (yearMonth: string) => {
-    set({ selectedMonth: yearMonth });
-  },
+    // 1ヶ月分の支出を抽出するAction
+    fetchExpensesByMonth: async (yearMonth: string) => {
+      set({ isLoading: true, error: null});
+      try {
+        const data = await getExpensesByMonth(yearMonth);
+        set({ monthlyExpenses: data});
+      } catch(e) {
+        set({ error: '支出の取得に失敗しました'});
+      } finally {
+        set({ isLoading: false});
+      }
+    },
 
-  addExpense: async (input) => {
-    set({ isLoading: true, error: null });
-    try {
-      const newExpense = await addExpense(input);
-      // 全期間のstateに費用を追加する
-      set((state) => ({ expenses: [...state.expenses, newExpense] }));
+    // 月を選択するAction
+    setSelectedMonth: (yearMonth: string) => {
+      set({ selectedMonth: yearMonth });
+    },
 
-      // 月別データの再取得をして月別データも更新する
-      const { selectedMonth } = useExpenseStore.getState();
-      const monthlyData = await getExpensesByMonth(selectedMonth);
-      set({ monthlyExpenses: monthlyData });
-    } catch (e) {
-      set({ error: '支出の追加に失敗しました' });
-    } finally {
-      set({ isLoading: false });
-    }
-  },
+    addExpense: async (input) => {
+      set({ isLoading: true, error: null });
+      try {
+        const newExpense = await addExpense(input);
+        // 全期間のstateに費用を追加する
+        set((state) => ({ expenses: [...state.expenses, newExpense] }));
 
-  updateExpense: async (id, input) => {
-    set({ isLoading: true, error: null });
-    try {
-      const updated = await updateExpense(id, input);
-      set((state) => ({
-        expenses: state.expenses.map((expense) => (expense.id === id ? updated : expense)),
-      }));
-    } catch (e) {
-      set({ error: '支出情報の更新に失敗しました' });
-    } finally {
-      set({ isLoading: false });
-    }
-  },
+        // 月別データの再取得をして月別データも更新する
+        await refreshMonthlyExpenses();
+      } catch (e) {
+        set({ error: '支出の追加に失敗しました' });
+      } finally {
+        set({ isLoading: false });
+      }
+    },
 
-  deleteExpense: async (id) => {
-    set({ isLoading: true, error: null });
-    try {
-      await deleteExpense(id);
-      set((state) => ({
-        expenses: state.expenses.filter((expense) => expense.id !== id),
-      }));
-    } catch (e) {
-      set({ error: '支出の削除に失敗しました' });
-    } finally {
-      set({ isLoading: false });
-    }
-  },
-}));
+    updateExpense: async (id, input) => {
+      set({ isLoading: true, error: null });
+      try {
+        const updated = await updateExpense(id, input);
+        set((state) => ({
+          expenses: state.expenses.map((expense) => (expense.id === id ? updated : expense)),
+        }));
+        await refreshMonthlyExpenses();
+      } catch (e) {
+        set({ error: '支出情報の更新に失敗しました' });
+      } finally {
+        set({ isLoading: false });
+      }
+    },
+
+    deleteExpense: async (id) => {
+      set({ isLoading: true, error: null });
+      try {
+        await deleteExpense(id);
+        set((state) => ({
+          expenses: state.expenses.filter((expense) => expense.id !== id),
+        }));
+        await refreshMonthlyExpenses();
+      } catch (e) {
+        set({ error: '支出の削除に失敗しました' });
+      } finally {
+        set({ isLoading: false });
+      }
+    },
+  };
+});

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  id: number;
+  name: string;
+};

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -1,4 +1,6 @@
 export type Category = {
   id: number;
   name: string;
+  icon: string;
+  bgColor: string;
 };

--- a/tamagui.config.ts
+++ b/tamagui.config.ts
@@ -13,13 +13,16 @@ const notoSansJP = createSystemFont({
 
 export const wanchoColors = {
   sage: '#ABB5A1',
+  mint: '#A8C5BB',
   sandBeige: '#E7E2DB',
+  camel: '#C4A882',
   charcoal: '#333333',
   greige: '#6F6F6F',
   ivory: '#FAFAF7',
   paleBlue: '#A7BBC9',
   palePink: '#EBC8C6',
   lavender: '#D7D6E2',
+  mauve: '#C4B5C4',
   lightGray: '#F2F2F2',
   white: '#FFFFFF',
   firebrick: '#b22222'

--- a/tamagui.config.ts
+++ b/tamagui.config.ts
@@ -26,6 +26,8 @@ export const wanchoColors = {
 }
 
 export const fontSizes = {
+  display: 28,
+  title: 24,
   heading1: 20,
   heading2: 18,
   body: 14,

--- a/tamagui.config.ts
+++ b/tamagui.config.ts
@@ -15,6 +15,7 @@ export const wanchoColors = {
   sage: '#ABB5A1',
   mint: '#A8C5BB',
   sandBeige: '#E7E2DB',
+  taupe: '#C2B5A3',
   camel: '#C4A882',
   charcoal: '#333333',
   greige: '#6F6F6F',


### PR DESCRIPTION
## Summary

- 記録一覧画面（月切り替え・合計表示・最近の支出リスト）を実装
- 支出追加・編集モーダル（カテゴリ選択・日付ピッカー・金額・メモ）を実装
- 全て見る画面（カテゴリフィルター・日付グループ表示）を実装
- スワイプで編集・削除アクション（`ReanimatedSwipeable`）を実装
- 削除前に確認ダイアログを表示する `ConfirmDialog` コンポーネントを追加
- `SwipeableExpenseRow` を共有コンポーネントとして抽出し `RecordScreen` でも再利用

## Test plan

- [x] 記録タブで月切り替えが動作し、合計金額が更新される
- [x] FAB（+ボタン）でモーダルが開き、支出を追加できる
- [x] 追加後にリストと合計金額が更新される
- [x] スワイプで編集ボタンを押すと編集モーダルが開き、更新できる
- [x] スワイプで削除ボタンを押すと確認ダイアログが表示され、削除できる
- [x] 「全て見る」でカテゴリフィルターと日付グループ表示が動作する
- [x] キーボード表示時に入力欄が隠れない

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Full expense recording interface with category selection and memo support
  * Monthly expense tracking with filtering by category
  * Swipeable rows for quick edit and delete actions
  * Confirmation dialogs for delete operations
  * Monthly expense totals display
  * Month-to-month navigation controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s-yamauchi07/wancho/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->