### PR TITLE
refactor: extract ExpenseRow from SwipeableExpenseRow and remove enableSwipe prop

### DIFF
--- a/src/components/record/ExpenseRow.tsx
+++ b/src/components/record/ExpenseRow.tsx
@@ -1,0 +1,72 @@
+import { XStack, YStack } from "@tamagui/stacks";
+import { SizableText } from "@tamagui/text";
+import { fontSizes, wanchoColors } from '../../../tamagui.config';
+import { FontAwesome6 } from "@expo/vector-icons";
+import { CATEGORIES } from '@/constants/categories';
+import { Expense } from "@/types/expense";
+
+type ExpenseRowProps = {
+  item: Expense;
+  showDate: boolean;
+}
+
+function formatAmount(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
+
+function formatDate(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  return `${Number(month)}/${Number(day)}`;
+}
+
+export const ExpenseRow = ({showDate, item }: ExpenseRowProps) => {
+  const category = CATEGORIES.find((c) => c.id === item.categoryId);
+
+  return(
+      <XStack
+        paddingVertical={12}
+        paddingHorizontal={16}
+        backgroundColor="$white"
+        borderBottomWidth={1}
+        borderBottomColor="$lightGray"
+        alignItems="center"
+        gap={12}
+      >
+        <YStack
+          width={36}
+          height={36}
+          borderRadius={18}
+          borderColor={category?.bgColor ?? wanchoColors.sage}
+          borderWidth={1}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <FontAwesome6
+            name={(category?.icon ?? 'ellipsis') as any}
+            size={18}
+            color={category?.bgColor ?? wanchoColors.greige}
+          />
+        </YStack>
+        <YStack flex={1}>
+          <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+            {category?.name ?? 'その他'}
+          </SizableText>
+          <XStack gap={4}>
+            {showDate && (
+              <SizableText fontSize={fontSizes.caption} color="$greige">
+                {formatDate(item.date)}
+              </SizableText>
+            )}
+            {item.memo && (
+              <SizableText fontSize={fontSizes.caption} color="$greige">
+                {item.memo}
+              </SizableText>
+            )}
+          </XStack>
+        </YStack>
+        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
+          {formatAmount(item.amount)}
+        </SizableText>
+      </XStack>
+  )
+}

--- a/src/components/record/SwipeableExpenseRow.tsx
+++ b/src/components/record/SwipeableExpenseRow.tsx
@@ -5,24 +5,14 @@ import { YStack, XStack } from '@tamagui/stacks';
 import { SizableText } from '@tamagui/text';
 import { FontAwesome6 } from '@expo/vector-icons';
 import { fontSizes, wanchoColors } from '../../../tamagui.config';
-import { CATEGORIES } from '@/constants/categories';
 import { Expense } from '@/types/expense';
+import { ExpenseRow } from './ExpenseRow';
 
 type SwipeableRowProps = {
   item: Expense;
   onEdit?: (item: Expense) => void;
   onDelete?: (item: Expense) => void;
   showDate: boolean;
-  enableSwipe?: boolean;
-}
-
-function formatAmount(amount: number): string {
-  return `¥${amount.toLocaleString()}`;
-}
-
-function formatDate(dateStr: string): string {
-  const [, month, day] = dateStr.split('-');
-  return `${Number(month)}/${Number(day)}`;
 }
 
 // 各費用リストの1行分のコンポーネント
@@ -31,9 +21,7 @@ export const SwipeableExpenseRow = ({
   onEdit,
   onDelete,
   showDate,
-  enableSwipe = true,
 } : SwipeableRowProps) => {
-  const category = CATEGORIES.find((c) => c.id === item.categoryId);
   const ref = useRef<SwipeableMethods | null>(null);
 
   const handleEdit = (item: Expense) => {
@@ -81,63 +69,16 @@ export const SwipeableExpenseRow = ({
     )
   };
 
-  const rowContent = (
-    <XStack
-      paddingVertical={12}
-      paddingHorizontal={16}
-      backgroundColor="$white"
-      borderBottomWidth={1}
-      borderBottomColor="$lightGray"
-      alignItems="center"
-      gap={12}
-    >
-      <YStack
-        width={36}
-        height={36}
-        borderRadius={18}
-        borderColor={category?.bgColor ?? wanchoColors.sage}
-        borderWidth={1}
-        alignItems="center"
-        justifyContent="center"
-      >
-        <FontAwesome6
-          name={(category?.icon ?? 'ellipsis') as any}
-          size={18}
-          color={category?.bgColor ?? wanchoColors.greige}
-        />
-      </YStack>
-      <YStack flex={1}>
-        <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-          {category?.name ?? 'その他'}
-        </SizableText>
-        <XStack gap={4}>
-          {showDate && (
-            <SizableText fontSize={fontSizes.caption} color="$greige">
-              {formatDate(item.date)}
-            </SizableText>
-          )}
-          {item.memo && (
-            <SizableText fontSize={fontSizes.caption} color="$greige">
-              {item.memo}
-            </SizableText>
-          )}
-        </XStack>
-      </YStack>
-      <SizableText fontSize={fontSizes.body} fontWeight="bold" color="$charcoal">
-        {formatAmount(item.amount)}
-      </SizableText>
-    </XStack>
-  );
-
-  if (!enableSwipe) return rowContent;
-
   return (
     <ReanimatedSwipeable
       ref={ref}
       renderRightActions={() => renderRightActions(item)}
       overshootRight={false}
     >
-      {rowContent}
+      <ExpenseRow 
+        item={item}
+        showDate={showDate}
+      />
     </ReanimatedSwipeable>
   );
 };

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -14,7 +14,7 @@ import { usePetStore } from '@/store/petStore';
 import { useExpenseStore } from '@/store/expenseStore';
 import { Expense } from '@/types/expense';
 import { CATEGORIES } from '@/constants/categories';
-import { SwipeableExpenseRow } from '@/components/record/SwipeableExpenseRow'
+import { ExpenseRow } from '@/components/record/ExpenseRow'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 export default function HomeScreen() {
@@ -275,10 +275,9 @@ export default function HomeScreen() {
               scrollEnabled={false} 
               keyExtractor={(item) => String(item.id)}
               renderItem={({item}) => (
-                <SwipeableExpenseRow
+                <ExpenseRow
                   item={item}
                   showDate={true} 
-                  enableSwipe={false}
                 />
               )}
               ListEmptyComponent={


### PR DESCRIPTION
## Summary
- `SwipeableExpenseRow` から行の表示ロジックを `ExpenseRow` として切り出し、責務を分離
- `SwipeableExpenseRow` は `ExpenseRow` をラップしてスワイプ操作のみを担う形にリファクタリング
- `HomeScreen` の `SwipeableExpenseRow(enableSwipe={false})` を `ExpenseRow` に差し替え、`enableSwipe` props を廃止

## Test plan
- [x] HomeScreenの「最近の支出」リストが正しく表示されることを確認する
- [x] AllRecordsScreenでスワイプして編集・削除ができることを確認する

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)